### PR TITLE
Preprocessing dwi

### DIFF
--- a/dwi_ml/data/processing/dwi/TO_SEND_TO_SCILPY.py
+++ b/dwi_ml/data/processing/dwi/TO_SEND_TO_SCILPY.py
@@ -111,45 +111,6 @@ def compute_dwi_attenuation(dwi_weights: np.ndarray, b0: np.ndarray):
     return dwi_attenuation
 
 
-def normalize_data_volume(data: np.ndarray, mask: Optional[np.ndarray] = None):
-    """Apply classic data standardization (zero-centering and variance
-    normalization) to every modality (last axis), restricted to a mask if
-    provided.
-
-    Parameters
-    ----------
-    data : np.ndarray with shape (X, Y, Z, #modalities)
-        Volume to normalize along each modality.
-    mask : binary np.ndarray with shape (X, Y, Z)
-        3D mask defining which voxels should be used for normalization. If None,
-        all non-zero voxels will be used.
-
-    Returns
-    -------
-    normalized_data : np.ndarray with shape (X, Y, Z, #modalities)
-        Normalized data volume, with zero-mean and unit variance along each
-        axis of the last dimension.
-    """
-    # Normalization in each direction (zero mean and unit variance)
-    if mask is None:
-        # If no mask is given, use non-zero data voxels
-        mask = np.zeros(data.shape[:3], dtype=np.int)
-        nonzero_idx = np.nonzero(data.sum(axis=-1))
-        mask[nonzero_idx] = 1
-    else:
-        # Mask resolution must fit DWI resolution
-        assert mask.shape == data.shape[:3], "Normalization mask resolution " \
-                                             "does not fit data..."
-
-    idx = np.nonzero(mask)
-    mean = np.mean(data[idx], axis=0)
-    std = np.std(data[idx], axis=0)
-
-    normalized_data = (data - mean) / (std + 1e-3)
-
-    return normalized_data
-
-
 def resample_dwi(dwi_image: nib.Nifti1Image, gradient_table: GradientTable,
                  directions: Sphere = None, sh_order: int = 8,
                  regul_coeff: float = 0.006):

--- a/dwi_ml/data/processing/dwi/dwi.py
+++ b/dwi_ml/data/processing/dwi/dwi.py
@@ -1,0 +1,77 @@
+
+from dipy.data import get_sphere
+from scilpy.reconst.raw_signal import compute_sh_coefficients
+import numpy as np
+
+
+def compute_sh_coefficients_resampled(dwi, gradient_table, sh_order=8,
+                                      basis_type='descoteaux07', smooth=0.006,
+                                      use_attenuation=False,
+                                      force_b0_threshold=False, mask=None,
+                                      sphere=None):
+    """Just a small function to remember our default sphere for SH resampling
+    on raw DWI. By default, we use "repulsion100".
+    """
+    if sphere is None:
+        sphere = get_sphere("repulsion100")
+
+    compute_sh_coefficients(dwi, gradient_table, sh_order, basis_type, smooth,
+                            use_attenuation, force_b0_threshold, mask,
+                            sphere=sphere)
+
+
+def standardize_data(data: np.ndarray, mask: np.ndarray = None,
+                     independant: bool = False):
+    """Apply classic data standardization (centralized, normalized = zero-
+    centering and variance to 1).
+
+    Parameters
+    ----------
+    data : np.ndarray with shape (X, Y, Z, #modalities)
+        Volume to normalize along each modality.
+    mask : binary np.ndarray with shape (X, Y, Z)
+        3D mask defining which voxels should be used for normalization. If None,
+        all non-zero voxels will be used. Voxels outside mask will be set to
+        nan.
+    independant: bool
+        If true, will normalize each modality independantly (last axis). Else,
+        will normalize with the mean and variance of all data. There is a
+        big reflexion to have here. Typical approach in machine learning is to
+        normalize each input X separately (each modality). But our data is not
+        independant. Ex, with peaks, the peak in one direction and the peak in
+        another must probably belong to the same distribution to mean something.
+        We recommand using independant = False for your dwi data.
+
+    Returns
+    -------
+    normalized_data : np.ndarray with shape (X, Y, Z, #modalities)
+        Normalized data volume, with zero-mean and unit variance along each
+        axis of the last dimension.
+    """
+    if mask is None:
+        # If no mask is given, use non-zero data voxels
+        mask = np.all(data != 0, axis=-1)
+    else:
+        # Mask resolution must fit DWI resolution
+        assert mask.shape == data.shape[:3], "Normalization mask resolution " \
+                                             "does not fit data..."
+
+    # Computing mean and std.
+    # Also dealing with extreme cases where std=0. Shouldn't happen. It means
+    # that this data is meaningless for your model. Here, we won't divide the
+    # data, just move its mean = value in all voxels will now be 0.
+    if independant:
+        mean = np.mean(data[mask], axis=0)
+        std = np.std(data[mask], axis=0)
+        std[std == 0] = 1
+    else:
+        mean = np.mean(data[mask])
+        std = np.std(data[mask])
+        if std == 0:
+            std = 1
+
+    normalized_data = (data - mean) / std
+    normalized_data[~mask] = np.nan
+
+    return normalized_data
+

--- a/dwi_ml/data/processing/dwi/dwi.py
+++ b/dwi_ml/data/processing/dwi/dwi.py
@@ -1,27 +1,16 @@
-
-from dipy.data import get_sphere
-from scilpy.reconst.raw_signal import compute_sh_coefficients
+# -*- coding: utf-8 -*-
 import numpy as np
 
 
-def compute_sh_coefficients_resampled(dwi, gradient_table, sh_order=8,
-                                      basis_type='descoteaux07', smooth=0.006,
-                                      use_attenuation=False,
-                                      force_b0_threshold=False, mask=None,
-                                      sphere=None):
-    """Just a small function to remember our default sphere for SH resampling
-    on raw DWI. By default, we use "repulsion100".
-    """
-    if sphere is None:
-        sphere = get_sphere("repulsion100")
-
-    compute_sh_coefficients(dwi, gradient_table, sh_order, basis_type, smooth,
-                            use_attenuation, force_b0_threshold, mask,
-                            sphere=sphere)
+# Note. If you want to resample DWI: you may use
+# from scilpy.reconst.raw_signal import compute_sh_coefficients
+# with the sphere
+# from dipy.data import get_sphere
+# sphere = get_sphere("repulsion100")
 
 
 def standardize_data(data: np.ndarray, mask: np.ndarray = None,
-                     independant: bool = False):
+                     independent: bool = False):
     """Apply classic data standardization (centralized, normalized = zero-
     centering and variance to 1).
 
@@ -33,14 +22,14 @@ def standardize_data(data: np.ndarray, mask: np.ndarray = None,
         3D mask defining which voxels should be used for normalization. If None,
         all non-zero voxels will be used. Voxels outside mask will be set to
         nan.
-    independant: bool
-        If true, will normalize each modality independantly (last axis). Else,
+    independent: bool
+        If true, will normalize each modality independently (last axis). Else,
         will normalize with the mean and variance of all data. There is a
         big reflexion to have here. Typical approach in machine learning is to
         normalize each input X separately (each modality). But our data is not
-        independant. Ex, with peaks, the peak in one direction and the peak in
+        independent. Ex, with peaks, the peak in one direction and the peak in
         another must probably belong to the same distribution to mean something.
-        We recommand using independant = False for your dwi data.
+        We recommend using independent = False for your dwi data.
 
     Returns
     -------
@@ -60,7 +49,7 @@ def standardize_data(data: np.ndarray, mask: np.ndarray = None,
     # Also dealing with extreme cases where std=0. Shouldn't happen. It means
     # that this data is meaningless for your model. Here, we won't divide the
     # data, just move its mean = value in all voxels will now be 0.
-    if independant:
+    if independent:
         mean = np.mean(data[mask], axis=0)
         std = np.std(data[mask], axis=0)
         std[std == 0] = 1

--- a/dwi_ml/data/processing/dwi/dwi.py
+++ b/dwi_ml/data/processing/dwi/dwi.py
@@ -74,4 +74,3 @@ def standardize_data(data: np.ndarray, mask: np.ndarray = None,
     normalized_data[~mask] = np.nan
 
     return normalized_data
-


### PR DESCRIPTION

Note. 
`from scilpy.reconst.raw_signal import compute_sh_coefficients`
Uses something from a PR in scilpy. We can wait for this to be accepted.
https://github.com/scilus/scilpy/pull/113