### PR TITLE
BUG: Add missing `sphinx_rtd_theme` package to doc requirements

### DIFF
--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
## Description
Add missing `sphinx_rtd_theme` package to doc requirements file.

Required [here](https://github.com/scil-vital/dwi_ml/blob/master/doc/conf.py#L57).

Fixes

```
$ ~/src/dwi_ml(master)$ make -C . clean && make -C . html
make : on entre dans le répertoire
« /src/dwi_ml »
make : on quitte le répertoire « /src/dwi_ml »
make : on entre dans le répertoire « /src/dwi_ml »
Running Sphinx v1.7.4
making output directory...
loading pickled environment... not yet created

Theme error:
sphinx_rtd_theme is no longer a hard dependency since version 1.4.0. Please
install it manually.(pip install sphinx_rtd_theme)
Makefile:20 : la recette pour la cible « html » a échouée
make: *** [html] Erreur 2
make : on quitte le répertoire « /src/dwi_ml »
```

## Have you
- [X] Added a description of the content of this PR above
- [X] Followed [proper commit message formatting](https://chris.beams.io/posts/git-commit/)
- [ ] Added data and a script to test this PR
- [ ] Made sure that PEP8 issues are resolved
- [X] Tested the code yourself right before pushing
- [ ] Added unit tests to test the code you implemented
