### PR TITLE
ENH: Add commit message-related pre-commit hooks

### DIFF
--- a/utils/gitsetup/setup-hooks.sh
+++ b/utils/gitsetup/setup-hooks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Run this script to set up local Git hooks for this project.
+
+egrep-q() {
+	egrep "$@" >/dev/null 2>/dev/null
+}
+
+die() {
+	echo 1>&2 "$@" ; exit 1
+}
+
+# Make sure we are inside the repository.
+cd "${BASH_SOURCE%/*}" &&
+
+# Populate ".git/hooks".
+echo 'Setting up git hooks...' &&
+git_dir=$(git rev-parse --git-dir) &&
+mkdir -p "$git_dir/hooks" &&
+cd "$git_dir/hooks" &&
+cp -ap "../../utils/hooks/." . &&
+if ! test -e .git; then
+	git init -q || die 'Could not run git init for hooks.'
+fi &&
+echo 'Done.'

--- a/utils/hooks/commit-msg
+++ b/utils/hooks/commit-msg
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# This commit message hook is inspired on the one in ITK.
+
+egrep-q() {
+  egrep "$@" >/dev/null 2>/dev/null
+}
+
+# Prepare a copy of the message:
+#  - strip comment lines
+#  - stop at "diff --git" (git commit -v)
+git_dir=$(git rev-parse --git-dir)
+commit_msg=$git_dir/COMMIT_MSG
+sed -n -e '/^#/d' -e '/^diff --git/q' -e 'p;d' "$1" > "$commit_msg"
+
+die() {
+  echo 'commit-msg hook failure' 1>&2
+  echo '-----------------------' 1>&2
+  echo '' 1>&2
+  echo "$@" 1>&2
+  echo '
+To continue editing, run the command
+  git commit -e -F '"$commit_msg"'
+(assuming your working directory is at the top).' 1>&2
+  exit 1
+}
+
+# Check the first line for a standard prefix.
+cat "$commit_msg" |
+while IFS='' read line; do
+  # Look for the first non-empty line.
+  len=$(echo -n "$line" | wc -c)
+  if test $len -gt 0; then
+    # Look for valid prefixes.
+    echo "$line" |
+    egrep-q '^(Merge|Revert|BUG:|COMP:|DOC:|ENH:|PERF:|STYLE:|WIP:) ' ||
+    die 'Start commit messages with a standard prefix (and a space):
+  BUG:    - fix for runtime crash or incorrect result
+  COMP:   - compiler error or warning fix
+  DOC:    - documentation change
+  ENH:    - new functionality
+  PERF:   - performance improvement
+  STYLE:  - no logic impact (indentation, comments)
+  WIP:    - Work In Progress not ready for merge'
+
+    # Done.  Skip rest of lines.
+    break
+  fi
+done &&
+rm -f "$commit_msg" || exit 1

--- a/utils/hooks/prepare-commit-msg
+++ b/utils/hooks/prepare-commit-msg
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# This commit message preparattion hook is inspired on the one in ITK.
+# It only works for French locales, since the target tokens to find an
+# appropriate place for the instructions are written in French in this script.
+
+egrep-q() {
+  egrep "$@" >/dev/null 2>/dev/null
+}
+
+# First argument is file containing commit message.
+commit_msg="$1"
+
+# Check for extra instructions.
+egrep-q "^# Start commit messages" -- "$commit_msg" && return 0
+
+# Insert extra instructions.
+commit_msg_tmp="$commit_msg.$$"
+instructions='#\
+# Start commit messages with a standard prefix (and a space):\
+#   BUG:    - fix for runtime crash or incorrect result\
+#   COMP:   - compiler error or warning fix\
+#   DOC:    - documentation change\
+#   ENH:    - new functionality\
+#   PERF:   - performance improvement\
+#   STYLE:  - no logic impact (indentation, comments)\
+#   WIP:    - Work In Progress not ready for merge\
+#
+# The first line of the commit message should preferably be 72 characters
+# or less; the maximum allowed is 78 characters.
+#
+# Follow the first line commit summary with an empty line, then a detailed
+# description in one or more paragraphs.
+#' &&
+sed '/^# Sur la branche.*$/ a\
+'"$instructions"'
+/^# Pas actuellement sur une branche.*$/ a\
+'"$instructions"'
+' "$commit_msg" > "$commit_msg_tmp" &&
+mv "$commit_msg_tmp" "$commit_msg"


### PR DESCRIPTION
## Description
Add commit message-related pre-commit hooks:
- `utils/hooks/prepare-commit-msg` inserts a custom message in the commit
  message comments showing the standard commit message subject prefixes.
- `utils/hooks/commit-msg` checks whether the commit message conforms to the
  standard prefixes.
- `utils/gitsetup/setup-hooks.sh` sets up the hooks.

## Have you
- [X] Added a description of the content of this PR above
- [X] Followed [proper commit message formatting](https://chris.beams.io/posts/git-commit/)
- [ ] Added data and a script to test this PR
- [ ] Made sure that PEP8 issues are resolved
- [ ] Tested the code yourself right before pushing
- [ ] Added unit tests to test the code you implemented
