### PR TITLE
Repairing the doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,18 +31,13 @@ tractography derivatives of dMRI.
 
 **Here is the usual workflow for people using dwi_ml**:
 
-..
-    Titles are imported.
-    1 = Organizing your data.
-    2 = Preprocessing your data
+1. `Organize your data <https://dwi-ml.readthedocs.io/en/latest/data_organization.html>`_. If your data is organized as expected, the following steps will be much easier.
 
-1. :ref:`ref_organization`. If your data is organized as expected, the following steps will be much easier. See
-
-2. :ref:`ref_preprocessing`
+2. `Preprocess your data <https://dwi-ml.readthedocs.io/en/latest/preprocessing.html>`_.
    - Preprocess your diffusion data using Tractoflow
    - Preprocess your tractogram using RecoBundlesX
 
-3. :ref:`ref_processing`
+3. `Create your own project with DWI_ML <https://dwi-ml.readthedocs.io/en/latest/processing.html>`_.
    - Create your own repository for your project.
    - Copy our scripts from ``please_copy_and_adapt``. Adapt based on your needs.
    - Train your ML algorithm

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ toolkit !
 Links
 =====
 
-* `Getting started <./doc/getting_started.rst>`_
-* `Submit a patch <./CONTRIBUTING.rst>`_
+* `Getting started: installation and download <https://dwi-ml.readthedocs.io/en/latest/getting_started.html>`_
+* `Contribute/Submit a patch <https://github.com/scil-vital/dwi_ml/blob/master/CONTRIBUTING.rst>`_
 * `Issue tracking <https://github.com/scil-vital/dwi_ml/issues>`_
 
 About
@@ -31,17 +31,22 @@ tractography derivatives of dMRI.
 
 **Here is the usual workflow for people using dwi_ml**:
 
-#. Preprocess your diffusion data using Tractoflow (see :ref:``ref_preprocessing``).
-#. Preprocess your tractogram using RecoBundlesX (see :ref:``ref_preprocessing``).
-#. Create a new repository for your project. Create a ``scripts_bash`` folder
-   and copy our scripts from ``please_copy_and_adapt``. Adapt based on your
-   needs and run:
+..
+    Titles are imported.
+    1 = Organizing your data.
+    2 = Preprocessing your data
 
- #. ``organize_from_tractoflow.sh``
- #. ``organize_from_recobundles.sh``
- #. ``create_dataset.sh``
- #. ``training.sh``
- #. ``tracking.sh``
+1. :ref:`ref_organization`. If your data is organized as expected, the following steps will be much easier. See
+
+2. :ref:`ref_preprocessing`
+   - Preprocess your diffusion data using Tractoflow
+   - Preprocess your tractogram using RecoBundlesX
+
+3. :ref:`ref_processing`
+   - Create your own repository for your project.
+   - Copy our scripts from ``please_copy_and_adapt``. Adapt based on your needs.
+   - Train your ML algorithm
+   - If needed, create your tracking algorithm based on your results.
 
 License
 =======

--- a/doc/creating_hdf5.rst
+++ b/doc/creating_hdf5.rst
@@ -1,3 +1,5 @@
+.. _ref_creating_hdf5:
+
 Creating the hdf5 file
 ======================
 

--- a/doc/data_organization.rst
+++ b/doc/data_organization.rst
@@ -1,7 +1,7 @@
 .. _ref_organization:
 
-How to organize your data
-=========================
+Organizing your data
+====================
 
 Folder division
 ***************

--- a/doc/devel/contributing_link.rst
+++ b/doc/devel/contributing_link.rst
@@ -1,0 +1,1 @@
+.. include:: ../../CONTRIBUTING.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,12 +1,31 @@
 Welcome to DWI_ML documentation!
 ================================
 
+This website is a guide to the github repository from the SCIL-VITAL organisation: https://github.com/scil-vital/dwi_ml/.
+
 .. toctree::
     :maxdepth: 1
-    :caption: Table of contents
+    :caption: Presentation
 
     readme_link
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Download and installation
+
     getting_started
-    preprocessing
+
+.. toctree::
+    :maxdepth: 1
+    :caption: How to use DWI_ML
+
     data_organization
-    creating_hdf5
+    preprocessing
+    processing
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Contributing
+
+    devel/contributing_link
+    devel/coding_style_guideline

--- a/doc/preprocessing.rst
+++ b/doc/preprocessing.rst
@@ -6,7 +6,11 @@ Preprocessing your data
 Preprocessing diffusion data
 ****************************
 
-See the `SCIL's documentation <https://scil-documentation.readthedocs.io/en/latest/?badge=latest>`_ for more information on how to preprocess your data using tractoflow. Then, see our :ref:`ref_organization` tab to learn to organize everything as we expect.
+See the `SCIL's documentation <https://scil-documentation.readthedocs.io/en/latest/?badge=latest>`_ for more information on how to preprocess your data using tractoflow. Then, see our :ref:`ref_organization` tab to learn to organize everything as we expect. If you need a reminder of tractoflow's outputs, you can check our page below.
+
+.. toctree::
+
+    reminder_tractoflow_output
 
 Preprocessing bundles
 *********************

--- a/doc/processing.rst
+++ b/doc/processing.rst
@@ -1,0 +1,22 @@
+.. _ref_processing:
+
+Creating your own project with DWI_ML
+=====================================
+
+1. Create your own repository for your project.
+
+2. Copy our scripts from ``please_copy_and_adapt``. Adapt based on your needs.
+
+When ready, you will be able to run, in order:
+
+     #. ``organize_from_tractoflow.sh``
+     #. ``organize_from_recobundles.sh``
+     #. ``create_dataset.sh``.
+     #. ``training.sh``.
+     #. ``tracking.sh``.
+
+More information can be found below (more to come).
+
+.. toctree::
+
+    creating_hdf5

--- a/doc/reminder_tractoflow_output.rst
+++ b/doc/reminder_tractoflow_output.rst
@@ -1,3 +1,6 @@
+.. _ref_tractoflow_structure:
+
+
 Tractoflow's output structure
 =============================
 


### PR DESCRIPTION
Here is the list of problems solved:

**- Some broken links :** Some double apostrophe :ref:`` oups`` should be changed to :ref:`aahh`. However, this works for the doc but not for the readme directly on github. Changing for reference as a link ( `link <to_this_link>`_), and also, removing all relative links (ex, ./here) to absolute links because github and the doc don't have the same root. Absolute links start with https://dwi-ml.readthedocs.io/en/latest/.

**- Making sure all pages are included :** some pages were not included in any toctree. 
- I added the page "processing" to regroup the future pages explaining everything similar to CreateHDF5, which was not included anywhere.
- The CONTRIBUTING page could not be included easily because it is outside the doc folder (as per a previous decision we took), so I added it with a link, the same was as the README.

**- Improving the welcome page :** The head page of the web site was only a table of content, with no text. A little sad! I also separated the table of content into subsections for a nicer look.
