### PR TITLE
WIP: Changing the trainerAbstract for yaml-parsed inputs

### DIFF
--- a/dwi_ml/training/checks_for_experiment_parameters.py
+++ b/dwi_ml/training/checks_for_experiment_parameters.py
@@ -13,9 +13,9 @@ def check_similar_to_none(var, var_name: str):
     understood as a string.
     """
     if var == 'None':
-        raise ValueError("You have set {} to None in yaml! Possible confusion, "
-                         "stopping here. If you want to set a variable to None "
-                         "with yaml, you should use ~ or "
+        raise ValueError("You have set {} to None in yaml! Possible "
+                         "confusion, stopping here. If you want to set a "
+                         "variable to None with yaml, you should use ~ or "
                          "null.".format(var_name))
     if var == 'null':
         raise ValueError("You have set {} to 'null'. Possible confusion, "
@@ -99,13 +99,15 @@ def check_experiment_name(name: str, required: bool = False):
     return name
 
 
-def check_hdf5_filename(filename: str, required: bool = False):
+def check_hdf5_filename(filename: str, required: bool = False) -> str:
+
     check_similar_to_none(filename, 'hdf5 filename')
     check_required_was_given(filename, 'hdf5 filename', required)
 
     if filename is not None and not path.exists(filename):
         raise ValueError("The hdf5 database was not found! "
                          "({})".format(filename))
+
     return filename
 
 
@@ -177,8 +179,8 @@ def check_neighborhood(sphere_radius: float, grid_radius: int):
         return 'sphere', sphere_radius
     elif grid_radius:
         return 'grid', grid_radius
-    else:
-        return None, None
+
+    return None, None
 
 
 def check_previous_dir(num_previous_dirs: int):
@@ -288,9 +290,7 @@ def check_seed(seed: int, required: bool = False):
 
 
 # Main check function
-
-
-def check_all_experiment_parameters(conf):
+def check_all_experiment_parameters(conf: dict):
     # Experiment:
     name = check_experiment_name(
         conf['experiment']['name'], required=False)

--- a/please_copy_and_adapt/ALL_STEPS.sh
+++ b/please_copy_and_adapt/ALL_STEPS.sh
@@ -28,7 +28,9 @@ create_hdf5_dataset.py --name $name --bundles $bundles --std_mask $mask \
 # 2. Training          #
 ########################
 
+yaml_file=training_parameters.yaml
 
+train_model.py $yaml_file
 
 ########################
 # 3. Validation        #

--- a/please_copy_and_adapt/train_model.py
+++ b/please_copy_and_adapt/train_model.py
@@ -52,13 +52,13 @@ def main():
     organized_args = check_all_experiment_parameters(conf)
 
     # Instantiate your class
-    # (Change StreamlinesBasedModelAbstract for your class.)
+    # (Change DWIMLAbstractSequences for your class.)
     # Then load dataset, build model, train and save
-    #experiment = DWIMLAbstractSequences(organized_args)
-    #experiment.load_dataset()
-    #experiment.build_model()
-    #experiment.train()
-    #experiment.save()
+    experiment = DWIMLAbstractSequences(organized_args)
+    experiment.load_dataset()
+    experiment.build_model()
+    experiment.train()
+    experiment.save()
 
 
 if __name__ == '__main__':

--- a/please_copy_and_adapt/train_model.py
+++ b/please_copy_and_adapt/train_model.py
@@ -25,8 +25,8 @@ def parse_args():
                                 formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('parameters_filename',
                    help='Experiment configuration YAML filename. See '
-                        'please_copy_and_adapt/training_parameters.yaml for an '
-                        'example.')
+                        'please_copy_and_adapt/training_parameters.yaml for '
+                        'an example.')
 
     arguments = p.parse_args()
     return arguments


### PR DESCRIPTION
## Description
In a previous PR (#42 ), we changed args parser to a yaml style in the file please_copy_and_adapt/train_model.py. This is now the next step: send this newly formation input structure to the trainer class.  
---> ``experiment = DWIMLAbstractSequences(organized_args)`` is now uncommented. And ready for use, i.e. users can now define their own functions 
``experiment.build_model()``
``experiment.train()``

## Testing data and script
Waiting for the PR #35 (Creating the hdf5) to be merged to be able to test with good data.