### PR TITLE
Updated requirements to fit scilpy's

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,14 @@
 tqdm==4.34.0
-dipy==1.1.1
 nibabel>=3.0.0
 PyYAML==5.3.1
 
 
 ## Necessary but should be installed with scilpy (01/2020):
 future==0.17.1
-numpy==1.16.2
-scipy==1.0.1
-h5py==2.9.0
-
+numpy==1.18.*
+scipy==1.4.*
+h5py==2.10.*
+dipy==1.3.*
 
 
 ## Not used here but installed with scilpy (01/2020):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ nibabel>=3.0.0
 PyYAML==5.3.1
 
 
-## Necessary but should be installed with scilpy (01/2020):
+## Necessary but should be installed with scilpy (Last check: 01/2020, version 1.1.0):
 future==0.17.1
 numpy==1.18.*
 scipy==1.4.*
@@ -11,7 +11,7 @@ h5py==2.10.*
 dipy==1.3.*
 
 
-## Not used here but installed with scilpy (01/2020):
+## Not used here but installed with scilpy (Last check: 01/2020, version 1.1.0):
 # bz2file==0.98
 # cycler==0.10.0
 # Cython==0.29.12


### PR DESCRIPTION
I installed dwi_ml today on python 3.7. after installing scilpy.

Requirements in scilpy have changed so I am updating our's to fit!