### PR TITLE
Improving organize_from_tractoflow and _from_recobundles

### DIFF
--- a/please_copy_and_adapt/organize_from_recobundles.sh
+++ b/please_copy_and_adapt/organize_from_recobundles.sh
@@ -19,9 +19,9 @@
 #     subject. Ex: RecobundlesX/multi_bundles
 # -subjects = The list of ALL subjects. You may choose later which ones will be
 #     in your training set/validation set/testing set. One subject per line.
-database_folder=YOUR DATABASE FOLDER
-recobundles_name=RecobundlesX/multi_bundles
-subject_list=SUBJECTS.txt
+database_folder=$1  # The root folder
+recobundles_name=$2 # Something like RecobundlesX/multi_bundles
+subject_list=$3     # SUBJECTS.txt
 
 # =====================================#
 #            MAIN SCRIPT               #
@@ -47,7 +47,9 @@ fi
 
 echo "Checks passed. Now reorganizing subjects"
 # Reorganizing all subjects
-while IFS= read -r subjid; do
+subjects=$(<$subject_list)
+for subjid in $subjects
+do
   echo "Reorganizing subject $subjid"
   subj_folder=$dwi_ml_ready_folder/$subjid
   recobundles_folder=$preprocessed_folder/$subjid/$recobundles_name
@@ -55,11 +57,12 @@ while IFS= read -r subjid; do
     mkdir $subj_folder/bundles
   fi
 
-  echo "creating symlinks"
   # bundles:
   cd $recobundles_folder
   for bundle in *.trk
   do
     ln -s $recobundles_folder/$bundle $subj_folder/bundles/recobundlesX_$bundle
   done
-done < $subject_list
+done
+
+echo "We have organized RecobundlesX results into dwi_ml_ready (bundles)".

--- a/please_copy_and_adapt/organize_from_tractoflow.sh
+++ b/please_copy_and_adapt/organize_from_tractoflow.sh
@@ -105,8 +105,8 @@ do
   ln -s $subj_preprocessed_folder/Segment_Tissues/${subjid}__mask_wm.nii.gz $subj_folder/masks/wm.nii.gz
 
   # bundles:
-  if [ ! -f $subj_preprocessed_folder/Tracking/${subjid}__tracking.trk ]; then echo "Subject's tractogram not found"; exit 1; fi
-  ln -s $subj_preprocessed_folder/Tracking/${subjid}__tracking.trk $subj_folder/bundles/tractoflow_wholebrain.trk
+  if [ ! -f $subj_preprocessed_folder/*Tracking/${subjid}__*tracking*.trk ]; then echo "Subject's tractogram not found"; exit 1; fi
+  ln -s $subj_preprocessed_folder/*Tracking/${subjid}__*tracking*.trk $subj_folder/bundles/tractoflow_wholebrain.trk
 
 done
 

--- a/please_copy_and_adapt/organize_from_tractoflow.sh
+++ b/please_copy_and_adapt/organize_from_tractoflow.sh
@@ -1,28 +1,35 @@
-################################################################################
-# This script will create symlinks in dwi_ml_ready, pointing to your data      #
-# from tractoflow for each subject:                                            #
-#    - Resample/dwi_resample                                                   #
-#         Last dwi output from tractoflow.                                     #
-#         Will be copied in dwi/dwi_tractoflow.                                #
-#    - Eddy/bval_eddy / bvec_eddy                                              #
-#         Will be copied in dwi/bval_tractoflow.                               #
-#    - DTI_metrics/fa.                                                         #
-#         Will be copied to dwi/fa.                                            #
-#    - Register_T1/t1_warp                                                     #
-#        Last T1 from tractoflow.                                              #
-#        Will be copied to anat/t1.                                            #
-#    - Segment_Tissues/map_wm.                                                 #
-#        Will be copied to anat/wm_map                                         #
-#    - Segment_Tissues/mask_wm.                                                #
-#        Will be copied to masks/wm                                            #
-#                                                                              #
-# If you need something else for your model, you can modify this script.       #
-#                                                                              #
-# See our doc for more information                                             #
+
+###############################################################################
+# Your tree should look like:                                                 #
+# derivatives                                                                 #
+#    ├── original (ex, tractoflow input)                                      #
+#    └── preprocessed (ex, tractoflow output + recobundle output)             #
+#    └── dwi_ml_ready: will be created now.                                   #
+#                                                                             #
+# This script will create symlinks in dwi_ml_ready, pointing to your data     #
+# from tractoflow for each subject:                                           #
+#       └── dwi:                                                              #
+#           └── dwi_tractoflow: Resample/dwi_resample                         #
+#               (It is the last dwi output from tractoflow.)                  #
+#           └── bval_tractoflow: Eddy/bval_eddy                               #
+#           └── bvec_tractoflow: Eddy/bvec_eddy                               #
+#           └── fa: DTI_metrics/fa                                            #
+#       └── anat :                                                            #
+#           └── t1_tractoflow: Register_T1/t1_warp                            #
+#               (It is the last T1 output from tractoflow.)                   #
+#           └── wm_map: Segment_Tissues/map_wm                                #
+#       └── masks :                                                           #
+#           └── wm: egment_Tissues/mask_wm                                    #
+#       └── bundles  :                                                        #
+#           └── tractoflow_wholebrain: Tracking/tracking                      #
+#                                                                             #
+# If you need something else for your model, you can modify this script.      #
+#                                                                             #
+# See our doc for more information                                            #
 # (https://dwi-ml.readthedocs.io/en/latest/data_organization.html#ref-organization).
-# We suppose that you have a "preprocessed" folder that contains RecobundlesX  #
-# results folder for each subject.                                             #
-################################################################################
+# We suppose that you have a "preprocessed" folder that contains RecobundlesX #
+# results folder for each subject.                                            #
+###############################################################################
 
 # =====================================#
 #  VARIABLES TO BE DEFINED BY THE USER #
@@ -31,8 +38,8 @@
 #     folder. Will eventually contain dwi_ml_ready/.
 # - subjects = The list of ALL subjects. You may choose later which ones will be
 #     in your training set/validation set/testing set. One subject per line.
-database_folder=YOUR WORKING FOLDER
-subject_list=SUBJECTS.txt
+database_folder=$1   # YOUR WORKING FOLDER
+subject_list=$2      # ex, SUBJECTS.txt
 
 # =====================================#
 #            MAIN SCRIPT               #
@@ -65,7 +72,9 @@ fi
 
 # Reorganizing all subjects
 echo "Checks passed. Now reorganizing subjects"
-while IFS= read -r subjid; do
+subjects=$(<$subject_list)
+for subjid in $subjects
+do
   echo "Reorganizing subject $subjid"
   subj_preprocessed_folder=$database_folder/preprocessed/$subjid
   subj_folder=$dwi_ml_ready_folder/$subjid
@@ -75,25 +84,30 @@ while IFS= read -r subjid; do
   mkdir $subj_folder/masks
   mkdir $subj_folder/bundles
 
-  echo "creating symlinks"
   # dwi:
+  if [ ! -f $subj_preprocessed_folder/Resample_DWI/${subjid}__dwi_resampled.nii.gz ]; then echo "Subject's DWI not found"; exit 1; fi
   ln -s $subj_preprocessed_folder/Resample_DWI/${subjid}__dwi_resampled.nii.gz $subj_folder/dwi/dwi_tractoflow.nii.gz
+  if [ ! -f $subj_preprocessed_folder/Eddy/${subjid}__bval_eddy ]; then echo "Subject's bval not found"; exit 1; fi
   ln -s $subj_preprocessed_folder/Eddy/${subjid}__bval_eddy $subj_folder/dwi/bval_tractoflow
+  if [ ! -f $subj_preprocessed_folder/Eddy/${subjid}__dwi_eddy_corrected.bvec ]; then echo "Subject's bvec not found"; exit 1; fi
   ln -s $subj_preprocessed_folder/Eddy/${subjid}__dwi_eddy_corrected.bvec $subj_folder/dwi/bvec_tractoflow
+  if [ ! -f $subj_preprocessed_folder/DTI_Metrics/${subjid}__fa.nii.gz ]; then echo "Subject's FA not found"; exit 1; fi
   ln -s $subj_preprocessed_folder/DTI_Metrics/${subjid}__fa.nii.gz $subj_folder/dwi/fa.nii.gz
 
   # anat:
-  ln -s $subj_preprocessed_folder/Register_T1/${subjid}__t1_warped.nii.gz $subj_folder/anat/t1.nii.gz
+  if [ ! -f $subj_preprocessed_folder/Register_T1/${subjid}__t1_warped.nii.gz ]; then echo "Subject's T1 not found"; exit 1; fi
+  ln -s $subj_preprocessed_folder/Register_T1/${subjid}__t1_warped.nii.gz $subj_folder/anat/t1_tractoflow.nii.gz
+  if [ ! -f $subj_preprocessed_folder/Segment_Tissues/${subjid}__map_wm.nii.gz ]; then echo "Subject's WM map not found"; exit 1; fi
   ln -s $subj_preprocessed_folder/Segment_Tissues/${subjid}__map_wm.nii.gz $subj_folder/anat/wm_map.nii.gz
 
   # masks:
+  if [ ! -f $subj_preprocessed_folder/Segment_Tissues/${subjid}__mask_wm.nii.gz ]; then echo "Subject's WM mask not found"; exit 1; fi
   ln -s $subj_preprocessed_folder/Segment_Tissues/${subjid}__mask_wm.nii.gz $subj_folder/masks/wm.nii.gz
 
   # bundles:
+  if [ ! -f $subj_preprocessed_folder/Tracking/${subjid}__tracking.trk ]; then echo "Subject's tractogram not found"; exit 1; fi
   ln -s $subj_preprocessed_folder/Tracking/${subjid}__tracking.trk $subj_folder/bundles/tractoflow_wholebrain.trk
 
-done < $subject_list
+done
 
-echo "We have organized tractoflow results into dwi_ml (dwi, anat, masks)".
-echo "We do not raise warnings if one file is not found. Please check that all data was indeed found."
-echo "Ex: 'for subj in dwi_ml_ready/*; do ls \$subj/dwi/*bvec*; done'"
+echo "We have organized tractoflow results into dwi_ml (dwi, anat, masks)"


### PR DESCRIPTION
## Description
--> The script did not work if the subject list was separated with spaces instead of newlines in $subjects_list. Changed the way to read the file. Tested, it now works in both cases.
--> We were printing information that checks were not done if all files existed for all subjects. I added these checks.
--> Improved the information in comments.

## Testing data and script
Here is how I tested on Béluga:
```
# Copy tractoflow output as symlinks
database_folder=./YOUR_PATH/hcp_1200/derivatives/
cp -as /home/USER/projects/rrg-descotea/datasets/hcp_1200/derivatives/tractoflow/output/results_ranByEmma/results/ $database_folder/processed
# Create subject list
cd .$database_folder/processed
echo s* > subjects_list.txt
bash organize_from_tractoflow.sh $database_folder $subject_list
```

## Have you
- [x ] Added a description of the content of this PR above
- [x ] Followed [proper commit message formatting](https://chris.beams.io/posts/git-commit/)
- [x ] Added data and a script to test this PR
- [ ] Made sure that PEP8 issues are resolved
- [x ] Tested the code yourself right before pushing
- [ ] Added unit tests to test the code you implemented
