### PR TITLE
STYLE: Reviewed output models + added tests

### DIFF
--- a/dwi_ml/model/direction_getter_models.py
+++ b/dwi_ml/model/direction_getter_models.py
@@ -5,58 +5,80 @@ from typing import Any, List, Tuple
 import dipy.data
 import numpy as np
 import torch
+from torch import Tensor
 from torch.distributions import Categorical, MultivariateNormal
 from torch.nn import (Linear, Dropout, ReLU, CosineSimilarity)
 from torch.nn.modules.distance import PairwiseDistance
+
+from dwi_ml.model.utils_for_gaussians import independent_gaussian_log_prob
+from dwi_ml.model.utils_for_fisher_von_mises import fisher_von_mises_log_prob
 
 DESCRIPTION = """
 MODELS:
     REGRESSION models: Simple regression to learn directly a direction (each 
     output size = 3 = [x,y,z]). This means that it is a deterministic output.
-        - CosineRegressionOutput: Model: a 2-layer NN
-                                  Loss: Cosine similarity
-        - L2RegressionOutput: Model: 2 Linear layers
-                              Loss: Pairwise distance
+        - CosineRegressionDirectionGetter:
+                Model: a 2-layer NN
+                Loss: Cosine similarity between the computed direction and the
+                      provided target direction.
+                      = cos(theta) = (y*t)/(||y|| ||t||)
+                      The mean of loss values for each step of the streamline
+                      is computed.
+        - L2RegressionDirectionGetter:
+                Model: 2 Linear layers
+                Loss: Pairwise distance
+                      = sqrt(sum(t_i - y_i)^2)
+                      The mean of loss values for each step of the streamline
+                      is computed.
                               
     CLASSIFICATION models: That means that the output is a probability over all
-    classes. We can decide how to sample the final direction. The classes depend 
-    on the model.
-        - SphereClassificationOutput: Model: a 2-layer NN *                                       
-                                      Classes: 100 discrete points on the sphere
-                                      (dipy.data.get_sphere('symmetric724'))
-                                      Loss: Negative log-likelyhood
+    classes. We can decide how to sample the final direction. The classes
+    depend on the model.
+        - SphereClassificationDirectionGetter:
+               Model: a 2-layer NN
+               Classes: 724 discrete points on the sphere
+                        (dipy.data.get_sphere('symmetric724'))
+               Loss: Negative log-likelyhood from a softmax (integrated inside
+               torch) = cross-entropy
 
-    GAUSSIAN models: Contrary to regression, who would learn the parameters 
+    GAUSSIAN models: Contrary to regression, which would learn the parameters
     (hidden through the weights) that would represent a function h such that
     y ~ h(x)  (we learn the *parameters*), gaussian processes learn directly 
     the *function probability*. See for ex here
     https://blog.dominodatalab.com/fitting-gaussian-process-models-python/
     The model learns to represent the mean and variance of all the functions 
-    that could represent the data. 
-        - SingleGaussianOutput: Model: a 2-layer NN for the mean and a 2-layer 
-                                NN for the variance.*
-                                Loss: Negative log-likelihood
-        - GaussianMixtureOutput: Model: (a 2-layer NN for the mean and a 2-layer 
-                                 NN for the variance.) for each of N Gaussians.*                  
-                                 Loss: Negative log-likelihood.
+    that could represent the data. We can decide how to sample the final
+    direction.
+        - SingleGaussianDirectionGetter:
+                Model: a 2-layer NN for the mean and a 2-layer NN for the
+                       variance.
+                Loss: Negative log-likelihood
+        - GaussianMixtureDirectionGetter:
+                Model: a 2-layer NN for the mean and a 2-layer NN for the
+                       variance, for each of N Gaussians.
+                Loss: Negative log-likelihood
 
-    FISHER VON MISES models: This model provides probabilistic outputs using the
-    Fisher - von Mises distribution, which resembles a gaussian on the sphere. 
-    As such, it does not require unit normalization when sampling, and should be
-    more stable while training.                                                                                          # toDo. Can we have a bit more (easy) explanation?
- 
-* p.s. Torch kind of does a softmax after although it is not explicit.
-                                                                         
-INPUTS:  Def: Here, we call 'input' the output of your experiment model. Ex, RNN.
-         Type: torch.tensor
+    FISHER VON MISES models: This model provides probabilistic outputs using
+    the Fisher - von Mises distribution, which resembles a gaussian on the
+    sphere. As such, it does not require unit normalization when sampling, and
+    should be more stable while training. We can decide how to sample the final
+    direction.
+                Model:  a 2-layer NN for the mean and a 2-layer NN for the
+                       'kappas'.
+                Loss: Negative log-likelihood
+
+INPUTS:  Def: Here, we call 'input' the output of your experiment model.
+              (Ex, from a RNN).
+         Type: tensor
          Size:
              - Sequence models: [batch_size*seq_len, nb_features]
               where seq_len is the nb of time steps in the sequence.
               So the input sequences are concatenated.
              - Local models: [batch_size, nb_features]
 
-OUTPUTS: Def: The model final outputs.
-         Type: torch.tensor
+OUTPUTS: Def: The model final outputs, corresponding to directions, i.e.
+              (x,y,z) coordinates.
+         Type: tensor
          Size: 
              - Sequence model: [batch_size*seq_len, 3]
              - Local models: [batch_size, 3]
@@ -67,14 +89,29 @@ TARGETS: Def: The target values (real Y) for the batch
              - Sequence models: [batch_size*seq_len, 3]
              - Local models: [batch_size, 3]
 """
+CHOSEN_SPHERE = 'symmetric724'
+eps = 1e-6
 
 
-class BaseTrackingOutputModel(torch.nn.Module):
+def init_2layer_fully_connected(input_size: int, output_size: int):
+    """
+    Defines a 2-layer fully connected network with sizes
+    input_size   -->   input_size/2   -->   output_size
+    """
+    h1_size = ceil(input_size / 2)
+    h1 = Linear(input_size, h1_size)
+    h2 = Linear(h1_size, output_size)
+    layers = [h1, h2]
+
+    return layers
+
+
+class AbstractDirectionGetterModel(torch.nn.Module):
     """
     Default static class attribute, to be redefined by sub-classes.
 
-    Prepares the main functions. All models will be similar in the way that they
-    all define layers. Then, we always apply self.loop_on_layers()
+    Prepares the main functions. All models will be similar in the way that
+    they all define layers. Then, we always apply self.loop_on_layers()
 
     input  -->  layer_i --> ReLu --> dropout -->  last_layer --> output
                   |                     |
@@ -82,9 +119,12 @@ class BaseTrackingOutputModel(torch.nn.Module):
     """
     supportsCompressedStreamlines = False
 
-    def __init__(self, dropout: float = None):
+    def __init__(self, dropout: float = 0.):
         """ Prepares the dropout and ReLU sub-layers"""
         super().__init__()
+
+        if dropout and (dropout < 0 or dropout > 1):
+            raise ValueError('Dropout rate should be between 0 and 1.')
         self.dropout = dropout
         if self.dropout:
             self.dropout_sublayer = Dropout(self.dropout)
@@ -92,8 +132,7 @@ class BaseTrackingOutputModel(torch.nn.Module):
             self.dropout_sublayer = lambda x: x
         self.relu_sublayer = ReLU()
 
-    def loop_on_layers(self, inputs: torch.tensor,
-                       layers: List[torch.nn.Module]):
+    def loop_on_layers(self, inputs: Tensor, layers: List[torch.nn.Module]):
         """
         Apply a list of layers, using the ReLU activation function and dropout
         in-between layers.
@@ -110,22 +149,22 @@ class BaseTrackingOutputModel(torch.nn.Module):
         outputs = layers[-1](layer_inputs)
         return outputs
 
-    def forward(self, inputs: torch.Tensor):
+    def forward(self, inputs: Tensor):
         # Will be implemented by each class
         raise NotImplementedError
 
-    def compute_loss(self, outputs: Any, targets: torch.Tensor) \
-            -> torch.Tensor:
+    def compute_loss(self, outputs: Any, targets: Tensor) -> Tensor:
         # Will be implemented by each class
         raise NotImplementedError
 
-    def sample_tracking_directions(self, outputs: torch.Tensor) \
-            -> torch.Tensor:
+    def sample_tracking_directions(self, outputs: Tensor) -> Tensor:
         # Will be implemented by each class
+        # For deterministic models, this is straightforward.
+        # For probabilistic models, we need to sample the tracking directions.
         raise NotImplementedError
 
 
-class CosineRegressionOutput(BaseTrackingOutputModel):
+class CosineRegressionDirectionGetter(AbstractDirectionGetterModel):
     """
     Regression model.
 
@@ -138,26 +177,24 @@ class CosineRegressionOutput(BaseTrackingOutputModel):
     Loss = negative cosine similarity.
     * If sequence: averaged on time steps and sequences.
     """
+    # Compressed streamlines not supported
+    supportsCompressedStreamlines = False
 
     def __init__(self, input_size: int, dropout: float = None):
         # Prepare the dropout, Relu, loop:
         super().__init__(dropout)
 
-        # Layers
-        hidden_size = ceil(input_size / 2)
-        h1 = Linear(input_size, hidden_size)
-        h2 = Linear(hidden_size, 3)
-        self.layers = [h1, h2]
+        self.layers = init_2layer_fully_connected(input_size, 3)
 
         # Loss will be applied on the last dimension.
         self.loss = CosineSimilarity(dim=-1)
 
-    def forward(self, inputs: torch.Tensor):
+    def forward(self, inputs: Tensor):
         """ Run the inputs through the loop on layers.  """
         output = self.loop_on_layers(inputs, self.layers)
         return output
 
-    def compute_loss(self, outputs: torch.Tensor, targets: torch.Tensor):
+    def compute_loss(self, outputs: Tensor, targets: Tensor):
         """
         Compute the average negative cosine similarity between the computed
         directions and the target directions.
@@ -173,8 +210,7 @@ class CosineRegressionOutput(BaseTrackingOutputModel):
         mean_loss = losses.mean()
         return mean_loss
 
-    def sample_tracking_directions(self, outputs: torch.Tensor) \
-            -> torch.Tensor:
+    def sample_tracking_directions(self, outputs: Tensor) -> Tensor:
         """
         In this case, the output is directly a direction, so we can use it as
         is for the tracking.
@@ -182,7 +218,7 @@ class CosineRegressionOutput(BaseTrackingOutputModel):
         return outputs
 
 
-class L2RegressionOutput(BaseTrackingOutputModel):
+class L2RegressionDirectionGetter(AbstractDirectionGetterModel):
     """
     Regression model.
 
@@ -200,24 +236,20 @@ class L2RegressionOutput(BaseTrackingOutputModel):
         # Prepare the dropout, Relu, loop:
         super().__init__(dropout)
 
-        # Layers
-        hidden_size = ceil(input_size / 2)
-        h1 = Linear(input_size, hidden_size)
-        h2 = Linear(hidden_size, 3)
-        self.layers = [h1, h2]
+        self.layers = init_2layer_fully_connected(input_size, 3)
 
         # Loss will be applied on the last dimension, by default in
         # PairWiseDistance
         self.loss = PairwiseDistance()
 
-    def forward(self, inputs: torch.Tensor):
+    def forward(self, inputs: Tensor):
         """
         Run the inputs through the loop on layers.
         """
         output = self.loop_on_layers(inputs, self.layers)
         return output
 
-    def compute_loss(self, outputs: torch.Tensor, targets: torch.Tensor):
+    def compute_loss(self, outputs: Tensor, targets: Tensor):
         """Compute the average negative cosine similarity between the computed
         directions and the target directions.
         """
@@ -226,8 +258,7 @@ class L2RegressionOutput(BaseTrackingOutputModel):
         mean_loss = losses.mean()
         return mean_loss
 
-    def sample_tracking_directions(self, outputs: torch.Tensor)\
-            -> torch.Tensor:
+    def sample_tracking_directions(self, outputs: Tensor) -> Tensor:
         """
         In this case, the output is directly a direction, so we can use it as
         is for the tracking.
@@ -235,54 +266,52 @@ class L2RegressionOutput(BaseTrackingOutputModel):
         return outputs
 
 
-class SphereClassificationOutput(BaseTrackingOutputModel):
+class SphereClassificationDirectionGetter(AbstractDirectionGetterModel):
     """
     Classification model.
 
-    Classes: 100 points on the sphere (dipy.data.get_sphere('symmetric724'))
+    Classes: 724 points on the sphere (dipy.data.get_sphere('symmetric724'))
 
     Model: Same as before, a 2-layer NN.
 
     Loss = negative log-likelihood.
     """
+    supportsCompressedStreamlines = False
 
     def __init__(self, input_size: int, dropout: float = None):
         # Prepare the dropout, Relu, loop:
         super().__init__(dropout)
 
         # Classes
-        self.sphere = dipy.data.get_sphere('symmetric724')
+        self.sphere = dipy.data.get_sphere(CHOSEN_SPHERE)
         self.vertices = torch.as_tensor(self.sphere.vertices,
                                         dtype=torch.float32)
         output_size = self.sphere.vertices.shape[0]
 
-        # Layers
-        hidden_size = ceil(input_size / 2)
-        h1 = Linear(input_size, hidden_size)
-        h2 = Linear(hidden_size, output_size)
-        self.layers = [h1, h2]
+        self.layers = init_2layer_fully_connected(input_size, output_size)
 
         # Loss will be defined in compute_loss, using torch distribution
 
-    def forward(self, inputs: torch.Tensor):
+    def forward(self, inputs: Tensor):
         """
         Run the inputs through the loop on layers.
         """
         logits = self.loop_on_layers(inputs, self.layers)
         return logits
 
-    def compute_loss(self, outputs: torch.Tensor, targets: torch.Tensor):
+    def compute_loss(self, outputs: Tensor, targets: Tensor):
         """
         Compute the negative log-likelihood for the targets using the
         model's logits.
         """
 
-        # Find the closest idx per time step per sequence in the batch:
+        # Find the closest class for each target direction
         target_idx = self._find_closest_vertex(targets)
         target_idx_tensor = torch.as_tensor(target_idx, dtype=torch.int16,
                                             device=outputs.device)
 
         # Create an official probability distribution from the logits
+        # Applies a softmax
         distribution = Categorical(logits=outputs)
 
         # Compute loss between distribution and target vertex
@@ -293,8 +322,7 @@ class SphereClassificationOutput(BaseTrackingOutputModel):
 
         return mean_loss
 
-    def sample_tracking_directions(self, outputs: torch.Tensor) \
-            -> torch.Tensor:
+    def sample_tracking_directions(self, outputs: Tensor) -> Tensor:
         """
         Sample a tracking direction on the sphere from the predicted class
         logits (=probabilities).
@@ -328,7 +356,7 @@ class SphereClassificationOutput(BaseTrackingOutputModel):
         return index
 
 
-class SingleGaussianOutput(BaseTrackingOutputModel):
+class SingleGaussianDirectionGetter(AbstractDirectionGetterModel):
     """
     Classification model
 
@@ -346,19 +374,12 @@ class SingleGaussianOutput(BaseTrackingOutputModel):
         super().__init__(dropout)
 
         # Layers
-        hidden_size = ceil(input_size / 2)
-
-        h1_mean = Linear(input_size, hidden_size)
-        h2_mean = Linear(hidden_size, 3)
-        self.layers_mean = [h1_mean, h2_mean]
-
-        h1_variance = Linear(input_size, hidden_size)
-        h2_variance = Linear(hidden_size, 3)
-        self.layers_variance = [h1_variance, h2_variance]
+        self.layers_mean = init_2layer_fully_connected(input_size, 3)
+        self.layers_variance = init_2layer_fully_connected(input_size, 3)
 
         # Loss will be defined in compute_loss, using torch distribution
 
-    def forward(self, inputs: torch.Tensor):
+    def forward(self, inputs: Tensor):
         """
         Run the inputs through the loop on layers.
         """
@@ -369,8 +390,7 @@ class SingleGaussianOutput(BaseTrackingOutputModel):
 
         return means, variances
 
-    def compute_loss(self, outputs: Tuple[torch.Tensor, torch.Tensor],
-                     targets: torch.Tensor):
+    def compute_loss(self, outputs: Tuple[Tensor, Tensor], targets: Tensor):
         """Compute the negative log-likelihood for the targets using the
         model's mixture of gaussians.
         """
@@ -387,9 +407,8 @@ class SingleGaussianOutput(BaseTrackingOutputModel):
         mean_loss = nll_losses.mean()
         return mean_loss
 
-    def sample_tracking_directions(self,
-                                   outputs: Tuple[torch.Tensor, torch.Tensor]) \
-            -> torch.Tensor:
+    def sample_tracking_directions(self, outputs: Tuple[Tensor, Tensor]) \
+            -> Tensor:
         """
         From the gaussian parameters, sample a direction.
         """
@@ -404,17 +423,23 @@ class SingleGaussianOutput(BaseTrackingOutputModel):
         return direction
 
 
-class GaussianMixtureOutput(BaseTrackingOutputModel):
+class GaussianMixtureDirectionGetter(AbstractDirectionGetterModel):
     """
     Same as SingleGaussian but with more than one Gaussian. This should account
     for branching bundles, distributing probability across space at branching
     points.
 
-    Model: (a 2-layer NN for the mean and a 2-layer NN for the variance.) for
+    Model: (a 2-layer NN for the mean and a 2-layer NN for the sigma.) for
     each of N Gaussians.
-    (Parameters:     N Gaussians * (1 mixture param + 3 means + 3 variances))
+    (Parameters:     N Gaussians * (1 mixture param + 3 means + 3 sigmas))
 
-    Loss: Negative log-likelihood.
+    Loss: Negative log-likelihood. Tyically, in the literature, Gaussian
+    mixtures are used with expectation-maximisation (EM). Here we simply update
+    the mixture parameters and the Gaussian parameters jointly, similar to
+    GMM in [1].
+
+    Refs:
+    [1] https://github.com/jych/cle/blob/master/cle/cost/__init__.py
     """
     # 3D Gaussian mixture supports compressed streamlines
     supportsCompressedStreamlines = True
@@ -424,32 +449,26 @@ class GaussianMixtureOutput(BaseTrackingOutputModel):
         # Prepare the dropout, Relu, loop:
         super().__init__(dropout)
 
-        self.n_gaussians = 3
+        self.n_gaussians = nb_gaussians
 
-        # Layers
-        hidden_size = ceil(input_size / 2)
+        # N Gaussians * (1 mixture param + 3 means + 3 sigmas)
+        # (no correlations between each Gaussian)
+        # Use separate *heads* for the mu and sigma, but concatenate gaussians
 
-        h1_mixture = Linear(input_size, hidden_size)
-        h2_mixture = Linear(hidden_size, self.n_gaussians)
-        self.layers_mixture = [h1_mixture, h2_mixture]
-
-        # 3 means for each gaussian
-        h1_mean = Linear(input_size, hidden_size)
-        h2_mean = Linear(hidden_size, 3 * self.n_gaussians)
-        self.layers_mean = [h1_mean, h2_mean]
-
-        # 3 variances for each gaussian
-        h1_variance = Linear(input_size, hidden_size)
-        h2_variance = Linear(hidden_size, 3 * self.n_gaussians)
-        self.layers_variance = [h1_variance, h2_variance]
+        self.layers_mixture = init_2layer_fully_connected(
+            input_size, 1 * self.n_gaussians)
+        self.layers_mean = init_2layer_fully_connected(
+            input_size, 3 * self.n_gaussians)
+        self.layers_sigmas = init_2layer_fully_connected(
+            input_size, 3 * self.n_gaussians)
 
         # Loss will be defined in compute_loss, using torch distribution
 
-    def forward(self, inputs: torch.Tensor):
+    def forward(self, inputs: Tensor):
         """
         Run the inputs through the loop on layers.
         """
-        mixture_logits = self.loop_on_layers(inputs, self.layers_mixture_logits)
+        mixture_logits = self.loop_on_layers(inputs, self.layers_mixture)
 
         means = self.loop_on_layers(inputs, self.layers_mean)
 
@@ -458,46 +477,39 @@ class GaussianMixtureOutput(BaseTrackingOutputModel):
 
         return mixture_logits, means, sigmas
 
-    def compute_loss(self,
-                     outputs: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
-                     targets: torch.Tensor):
+    def compute_loss(self, outputs: Tuple[Tensor, Tensor, Tensor],
+                     targets: Tensor):
         """
         Compute the negative log-likelihood for the targets using the
         model's mixture of gaussians.
         """
+        # Note. Shape of targets: [batch_size*seq_len, 3] or [batch_size, 3]
+
         # Shape : [batch_size*seq_len, n_gaussians, 3] or
-        # [batch_size, n_gaussians, 3}
-        mixture_logits, means, variances = self._get_gaussian_parameters(outputs)
+        #         [batch_size, n_gaussians, 3]
+        mixture_logits, means, sigmas = self._get_gaussian_parameters(outputs)
 
         # Take softmax for the mixture parameters
         mixture_probs = torch.softmax(mixture_logits, dim=-1)
 
-        # Compute the difference between the means and the targets
-        diff = means - targets[:, None, :]
+        gaussians_log_prob = independent_gaussian_log_prob(targets[:, None, :],
+                                                           means, sigmas)
 
-        # Compute mahalanobis distance
-        square_m_distance = (diff / variances).pow(2).sum(dim=-1)
-
-        # Compute the log-probabilities and log-likelihood
-        log_det = variances.log().sum(dim=-1)
-        log_2pi = np.log(2 * np.pi).astype(np.float32)
-        gaussians_log_prob = -0.5 * ((3 * log_2pi) + square_m_distance)\
-                             - log_det
         nll_losses = -torch.logsumexp(mixture_probs.log() + gaussians_log_prob,
-                                    dim=-1)
+                                      dim=-1)
         mean_loss = nll_losses.mean()
 
         return mean_loss
 
-    def sample_tracking_directions(
-            self, outputs: Tuple[torch.Tensor, torch.Tensor, torch.Tensor]) \
-            -> torch.Tensor:
+    def sample_tracking_directions(self,
+                                   outputs: Tuple[Tensor, Tensor, Tensor]) \
+            -> Tensor:
         """
         From the gaussian mixture parameters, sample one of the gaussians
         using the mixture probabilities, then sample a direction from the
         selected gaussian.
         """
-        mixture_logits, means, variances = self._get_gaussian_parameters(outputs)
+        mixture_logits, means, sigmas = self._get_gaussian_parameters(outputs)
 
         # Create probability distribution and sample a gaussian per point
         # (or per time step per sequence)
@@ -505,10 +517,10 @@ class GaussianMixtureOutput(BaseTrackingOutputModel):
         mixture_id = mixture_distribution.sample()
 
         # For each point in the batch (of concatenate sequence) take the mean
-        # and variance parameters. Note. Means and variances are of shape
+        # and sigma parameters. Note. Means and sigmas are of shape
         # [batch_size*seq_len, n_gaussians, 3] or [batch_size, n_gaussians, 3]
         component_means = means[:, mixture_id, :]
-        component_sigmas = variances[:, mixture_id, :]
+        component_sigmas = sigmas[:, mixture_id, :]
 
         # Sample a final function in the chosen Gaussian
         # One direction per timestep per sequence.
@@ -519,23 +531,22 @@ class GaussianMixtureOutput(BaseTrackingOutputModel):
 
         return direction
 
-    def _get_gaussian_parameters(
-            self,
-            model_output: Tuple[torch.Tensor, torch.Tensor, torch.Tensor]) \
-            -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def _get_gaussian_parameters(self,
+                                 model_output: Tuple[Tensor, Tensor, Tensor]) \
+            -> Tuple[Tensor, Tensor, Tensor]:
         """From the model output, extract the mixture parameters, the means
-        and the variances, all reshaped according to the number of components
+        and the sigmas, all reshaped according to the number of components
         and the dimensions (3D). i.e. [batch_size, n_gaussians] for the mixture
-        logit and [batch_size, n_gaussians, 3] for the means and variances.
+        logit and [batch_size, n_gaussians, 3] for the means and sigmas.
         """
         mixture_logits = model_output[0].squeeze(dim=1)
         means = model_output[1].reshape((-1, self.n_gaussians, 3))
-        variances = model_output[2].reshape((-1, self.n_gaussians, 3))
+        sigmas = model_output[2].reshape((-1, self.n_gaussians, 3))
 
-        return mixture_logits, means, variances
+        return mixture_logits, means, sigmas
 
 
-class FisherVonMisesOutput(BaseTrackingOutputModel):
+class FisherVonMisesDirectionGetter(AbstractDirectionGetterModel):
     """
     This model provides probabilistic outputs using the Fisher - von Mises
     distribution [1][2], which resembles a gaussian on the sphere. As such,
@@ -544,34 +555,27 @@ class FisherVonMisesOutput(BaseTrackingOutputModel):
 
     We sample using rejection sampling defined in [3], implemented in [4].
 
+    Parameters are mu and kappa. Larger kappa leads to a more concentrated
+    cluster of points, similar to sigma for Gaussians.
+
     Ref:
     [1]: https://en.wikipedia.org/wiki/Von_Mises%E2%80%93Fisher_distribution
     [2]: http://www.mitsuba-renderer.org/~wenzel/files/vmf.pdf
     [3]: Directional Statistics (Mardia and Jupp, 1999)
     [4]: https://github.com/jasonlaska/spherecluster
     """
+    supportsCompressedStreamlines = False
 
-    def __init__(self, input_size: int, dropout: float = None,
-                 nb_gaussians: int = 3):
+    def __init__(self, input_size: int, dropout: float = None):
         # Prepare the dropout, Relu, loop:
         super().__init__(dropout)
 
-        # Layers
-        hidden_size = ceil(input_size / 2)
-
-        # Mean (3D)
-        h1_mean = Linear(input_size, hidden_size)
-        h2_mean = Linear(hidden_size, 3)
-        self.layers_mean = [h1_mean, h2_mean]
-
-        # Kappa (1 value)
-        h1_kappa = Linear(input_size, hidden_size)
-        h2_kappa = Linear(hidden_size, 1)
-        self.layers_variance = [h1_kappa, h2_kappa]
+        self.layers_mean = init_2layer_fully_connected(input_size, 3)
+        self.layers_kappa = init_2layer_fully_connected(input_size, 1)
 
         # Loss will be defined in compute_loss, using torch distribution
 
-    def forward(self, inputs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, inputs: Tensor) -> Tuple[Tensor, Tensor]:
         """Run the inputs through the fully-connected layer.
 
         Returns
@@ -594,34 +598,22 @@ class FisherVonMisesOutput(BaseTrackingOutputModel):
 
         return means, kappas
 
-    def compute_loss(self, outputs: Tuple[torch.Tensor, torch.Tensor],
-                     targets: torch.Tensor):
+    def compute_loss(self, outputs: Tuple[Tensor, Tensor], targets: Tensor):
         """Compute the negative log-likelihood for the targets using the
         model's mixture of gaussians.
         """
         # mu.shape : [flattened_sequences, 3]
         mu, kappa = outputs
 
-        log_2pi = np.log(2 * np.pi).astype(np.float32)
-
-        # Add an epsilon in case kappa is too small (i.e. a uniform
-        # distribution)
-        eps = 1e-6
-        log_diff_exp_kappa = torch.log(torch.exp(kappa)
-                                       - torch.exp(-kappa)
-                                       + eps)
-
-        batch_dot_product = torch.sum(mu * targets, dim=1)
-
-        nll_losses = -torch.log(kappa) + log_2pi + log_diff_exp_kappa - \
-                   (kappa * batch_dot_product)
+        log_prob = fisher_von_mises_log_prob(mu, kappa, targets, eps)
+        nll_losses = -log_prob
 
         mean_loss = nll_losses.mean()
 
         return mean_loss
 
-    def sample_tracking_directions(
-            self, outputs: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
+    def sample_tracking_directions(self, outputs: Tuple[Tensor, Tensor]) \
+            -> Tensor:
         """Sample directions from a fisher von mises distribution.
         """
         # mu.shape : [flattened_sequences, 3]
@@ -673,9 +665,34 @@ class FisherVonMisesOutput(BaseTrackingOutputModel):
         return orthto / np.linalg.norm(orthto)
 
 
-OUTPUT_KEY_TO_CLASS = {'cosine-regression': CosineRegressionOutput,
-                       'l2-regression': L2RegressionOutput,
-                       'sphere-classification': SphereClassificationOutput,
-                       'gaussian': SingleGaussianOutput,
-                       'gaussian-mixture': GaussianMixtureOutput,
-                       'fisher-von-mises': FisherVonMisesOutput}
+class FisherVonMisesMixtureDirectionGetter(AbstractDirectionGetterModel):
+    """
+    Compared to the version with 1 disbstribution, we now have an additional
+    weight parameter alpha.
+    """
+    def __init__(self, input_size: int, dropout: float = None,
+                 n_cluster: int = 3):
+        super().__init__(dropout)
+
+        self.n_cluster = n_cluster
+        raise NotImplementedError
+
+    def forward(self, inputs: Tensor) -> Tuple[Tensor, Tensor]:
+        raise NotImplementedError
+
+    def compute_loss(self, outputs: Tuple[Tensor, Tensor], targets: Tensor):
+        raise NotImplementedError
+
+    def sample_tracking_directions(self, outputs: Tuple[Tensor, Tensor]) \
+            -> Tensor:
+        raise NotImplementedError
+
+
+KEY_TO_DIRECTION_GETTER_MODEL = \
+    {'cosine-regression': CosineRegressionDirectionGetter,
+     'l2-regression': L2RegressionDirectionGetter,
+     'sphere-classification': SphereClassificationDirectionGetter,
+     'gaussian': SingleGaussianDirectionGetter,
+     'gaussian-mixture': GaussianMixtureDirectionGetter,
+     'fisher-von-mises': FisherVonMisesDirectionGetter,
+     'fisher-von-mises-mixture': FisherVonMisesMixtureDirectionGetter}

--- a/dwi_ml/model/utils_for_fisher_von_mises.py
+++ b/dwi_ml/model/utils_for_fisher_von_mises.py
@@ -1,0 +1,55 @@
+import numpy as np
+import torch
+
+"""
+Variables:
+    v = the normalized target
+    mu = the mean
+    kappa = the concentration parameter
+    d = the dimension
+
+Formulas:
+
+    1. Probability function:
+            P(v | mu, kappa) = C exp(kappa*mu^T*v)
+
+        Where C = the distribution normalizing constant and I_n = the modified
+        Bessel function at order n (see [3]).
+            C(kappa) = (kappa)^(d/2-1) / ((2π)^d/2 * I_(d/2-1)(kappa))
+
+        In our case, d=3:
+            C = kappa / (2*pi*(exp(kappa) - exp(-kappa)))
+
+    2. log-likelihood:
+            log(P(v)) = log(C exp(kappa*mu^T*v))
+                      = log(C) + kappa*mu^T*v
+
+            log(C) = log(kappa) - log(2pi) - log(exp(kappa)-exp(-kappa)
+
+    Refs:
+    [1]: https://en.wikipedia.org/wiki/Von_Mises%E2%80%93Fisher_distribution
+    [2]: http://www.mitsuba-renderer.org/~wenzel/files/vmf.pdf
+    [3]: https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1
+"""
+
+
+def fisher_von_mises_log_prob_vector(mus, kappa, targets):
+    log_c = np.log(kappa) - np.log(2 * np.pi) - np.log(np.exp(kappa) -
+                                                       np.exp(-kappa))
+    log_prob = log_c + (kappa * (mus * targets).sum(axis=-1))
+    return log_prob
+
+
+def fisher_von_mises_log_prob(mus, kappa, targets, eps=1e-6):
+    log_2pi = np.log(2 * np.pi).astype(np.float32)
+
+    # Add an epsilon in case kappa is too small (i.e. a uniform
+    # distribution)
+    log_diff_exp_kappa = torch.log(torch.exp(kappa) - torch.exp(-kappa) + eps)
+    log_c = torch.log(kappa) - log_2pi - log_diff_exp_kappa
+
+    batch_dot_product = torch.sum(mus * targets, dim=1)
+
+    log_prob = log_c + (kappa * batch_dot_product)
+
+    return log_prob

--- a/dwi_ml/model/utils_for_gaussians.py
+++ b/dwi_ml/model/utils_for_gaussians.py
@@ -1,0 +1,110 @@
+import numpy as np
+from scipy.spatial.distance import mahalanobis
+import torch
+
+"""
+Variables:
+    C = the covariance matrix. It indicates the relations between each all
+        dimensions x,y,z. C is diagonal if the axis are independant, with
+        the variances on the diagonal.
+    N(x) = The normal distribution
+    d = the dimension of data (here, 3: x,y,z)
+
+Formulas:
+    1.  Square Mahalanobis distance for one Gaussian:
+            m^2 = (x - mu)^T * inv(C) * (x - mu)
+
+        *For independant variables:
+            m^2 = sum_d [(x - mu)^2 / sigma^2]
+
+    2. Probability function for a single multivariate Gaussian:
+            P(x) =  N(x | mu, C)
+                =  1 / sqrt(   det(2pi * C)  ) * exp(-0.5m^2)
+        Knowing that det(kX) = k^d*det(X) where d=the size of X
+                =  1 / sqrt(  (2pi)^d * det(C)   ) * exp(-0.5m^2)
+
+        *If the variables (x,y,z axis) are independent, det(C) = sum(sigma^2).
+
+    3. Log-likelihood of a single gaussian:
+        log(P(x) = -0.5( dlog(2pi) + m^2) - sum(log(sigma))
+
+
+    4. Probability function for a mixture of multivariate Gaussians
+            P(X=x) = sum_k (P(X=x | Z=k)*P(Z=k)
+
+        We note z_i = P(Z=k), the probability of observing a point that came
+        from the ith Gaussian. It is actually equivalent to the mixing
+        coefficient for that Gaussian.
+            P(x) = sum_K (z_i *  N(x | mu_i, C_i))
+                 = sum_K (z_i /sqrt(  (2pi)^d*det(C_i)  ) * exp(-0.5m_i^2))
+
+    5. Log-likelihood for a mixture of Gaussians:
+            log(P(x)) = log( sum_K (z_i /sqrt(  (2pi)^d*det(C_i)  ) * exp(-0.5m_i^2)) )
+
+        If z_i is already known (mixture_probs, computed separately), it is
+        easy to separate this variable in the computation by using
+        x = exp(log(x))
+
+           log(P(x)) = log(sum_K(exp(log(  (z_i /sqrt((2pi)^d*det(C_i)) * exp(-0.5m_i^2)  ))))
+                     = ...
+                     = logsumexp( log(z_i) - 0.5(  d*log(2pi) + log(det(C_i)) + m_i^2  ))
+
+        *For independant variables: det(C) = product of diagonal = sum(sigma^2)
+                    = logsumexp( log(z_i) - 0.5( d*log(2pi) + m_i^2 ) -0.5log(det(C_i)) )
+                    = logsumexp( log(z_i) - 0.5( d*log(2pi) + m_i^2 ) -sum(log(sigma)))
+                                          -------------------------------------------
+                                           This part is the logpdf of a single Gaussian!
+                    = logsumexp( log(z_i) + logpdf_i)
+
+   ref:
+      https://en.wikipedia.org/wiki/Mahalanobis_distance
+      https://stephens999.github.io/fiveMinuteStats/intro_to_em.html
+      https://www.ee.columbia.edu/~stanchen/spring16/e6870/slides/lecture3.pdf
+      https://github.com/jych/cle/blob/master/cle/cost/__init__.py
+    """
+d = 3
+
+
+def independent_gaussian_log_prob_vector(x, mus, sigmas):
+    """
+    Parameters
+    ----------
+    x = the variable
+    mu = mean of the gaussian (x,y,z directions)
+    sigmas = standard deviation of the gaussian (x,y,z directions)
+    """
+    # The inverse of a diagonal matrix is just inversing values on the
+    # diagonal
+    cov_inv = np.eye(d) * (1 / sigmas ** 2)
+
+    # sum(log) = log(prod)
+    logpdf = -d / 2 * np.log(2 * np.pi) - np.log(np.prod(sigmas)) \
+             - 0.5 * mahalanobis(x[:3], mus, cov_inv) ** 2
+    return logpdf
+
+
+def independent_gaussian_log_prob(targets, mus, sigmas):
+    """
+    This function computes the log likelihood for **individual** multivariate
+    Gaussians, computed from tensors.
+
+    If K>1 (the number of Gaussians), then the variables mu and sigma contain
+    the information for many Gaussians, and log likelihoods for each Gaussian
+    are returned.
+
+    Parameters
+    ----------
+    targets: torch.tensor
+        The variable, of shape [batch_size, none, d], d=3.
+    mus: torch.tensor
+        The mean, of size [batch_size, n, d], d=3.
+    sigmas: torch.tensor
+        The standard deviation
+    """
+    log_2pi = np.log(2 * np.pi).astype(np.float32)
+    squared_m = ((targets - mus) / sigmas).pow(2).sum(dim=-1)
+    log_det = sigmas.log().sum(dim=-1)
+
+    gaussians_log_prob = -0.5 * (d * log_2pi + squared_m) - log_det
+
+    return gaussians_log_prob

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+torch
 tqdm==4.34.0
 nibabel>=3.0.0
 PyYAML==5.4

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,5 @@ setup(
     package_data={},
     data_files=[],
     entry_points={},
-    scripts=glob.glob("scripts_python/*.py")
+    scripts=glob.glob("scripts_python/*.py") + glob.glob("tests/*.py")
 )

--- a/tests/test_direction_getter_models.py
+++ b/tests/test_direction_getter_models.py
@@ -1,0 +1,350 @@
+from dipy.data import get_sphere
+from dwi_ml.model.direction_getter_models import (
+    CosineRegressionDirectionGetter, FisherVonMisesDirectionGetter,
+    GaussianMixtureDirectionGetter, L2RegressionDirectionGetter,
+    SingleGaussianDirectionGetter, SphereClassificationDirectionGetter)
+from dwi_ml.model.utils_for_gaussians import (
+    independent_gaussian_log_prob_vector)
+from dwi_ml.model.utils_for_fisher_von_mises import (
+    fisher_von_mises_log_prob_vector)
+from nose.tools import assert_equal
+import numpy as np
+from scipy.spatial.distance import (cosine, euclidean)
+from scipy.special import logsumexp, softmax
+import torch
+from torch.nn.utils.rnn import PackedSequence
+
+
+"""
+Included tests are:
+    test_cosine_regression_loss()
+        - identical vectors
+        - vectors with same angles
+        - vectors at 90 degrees
+        - vectors at 180 degrees
+        - comparison with scipy.spatial.distance.cosine
+    test_l2regression_loss()
+        - identical vectors
+        - comparison with scipy.spatial.distance.euclidean
+    test_gaussian_loss()
+        - x = mu
+        - comparison with (manual + scipy)
+    test_mixture_loss()
+        - comparison with (manual + scipy)
+"""
+# toDo
+#  test fisher von mises
+
+tol = 1e-5
+
+
+def get_random_vector(size=3):
+    scaling = np.random.randint(1, 10)
+    return np.array(np.random.randn(size), dtype=np.float32) * scaling
+
+
+def prepare_tensor(a):
+    if isinstance(a, tuple):
+        a = tuple([torch.as_tensor(i[None, :], dtype=torch.float32)
+                   for i in a])
+    elif isinstance(a, np.ndarray):
+        a = torch.as_tensor(a[None, :], dtype=torch.float32)
+    return a
+
+
+def prepare_packedsequence(a):
+    if not isinstance(a, PackedSequence):
+        a = PackedSequence(data=(torch.as_tensor(a[None, :],
+                                                 dtype=torch.float32)),
+                           batch_sizes=torch.as_tensor([1]))
+        return a
+
+
+def prepare_tensor_and_compute_loss(outputs, targets, model):
+    outputs = prepare_tensor(outputs)
+    targets = prepare_tensor(targets)
+    mean_loss = model.compute_loss(outputs, targets).item()
+
+    return mean_loss
+
+
+def prepare_packedsequence_and_compute_loss(outputs, targets, model):
+    outputs = prepare_tensor(outputs)
+    targets = prepare_packedsequence(targets)
+    mean_loss = model.compute_loss(outputs, targets.data).item()
+
+    return mean_loss
+
+
+def test_cosine_regression_loss():
+    np.random.seed(1234)
+    model = CosineRegressionDirectionGetter(1)
+
+    # Test identical vectors
+    a = np.array([1, 0, 0])
+    b = np.array([1, 0, 0])
+    expected = np.array(-1)
+    value = prepare_tensor_and_compute_loss(a, b, model)
+    assert_equal(value, expected)
+
+    # Test identical vectors
+    a = np.array([0, 1, 0])
+    b = np.array([0, 1, 0])
+    expected = np.array(-1)
+    value = prepare_tensor_and_compute_loss(a, b, model)
+    assert_equal(value, expected)
+
+    # Test identical vectors
+    a = np.array([0, 0, 1])
+    b = np.array([0, 0, 1])
+    expected = np.array(-1)
+    value = prepare_tensor_and_compute_loss(a, b, model)
+    assert_equal(value, expected)
+
+    # Test vectors with same angle
+    scales = np.random.random(20) * 20
+    for s in scales:
+        a = np.array([1, 0, 0])
+        b = a * s
+        expected = np.array(-1)
+        value = prepare_tensor_and_compute_loss(a, b, model)
+        assert_equal(value, expected)
+
+    # Test vectors at 90 degrees
+    a = np.array([1, 0, 0])
+    b = np.array([0, 1, 0])
+    expected = np.array(0)
+    value = prepare_tensor_and_compute_loss(a, b, model)
+    assert_equal(value, expected)
+
+    # Test vectors at 90 degrees
+    a = np.array([1, 0, 0])
+    b = np.array([0, 0, 1])
+    expected = np.array(0)
+    value = prepare_tensor_and_compute_loss(a, b, model)
+    assert_equal(value, expected)
+
+    # Test vectors at 90 degrees
+    for _ in range(20):
+        a = get_random_vector(3)
+        b = get_random_vector(3)
+        c = np.cross(a, b)
+        expected = np.array(0)
+
+        value = prepare_tensor_and_compute_loss(a, c, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+        value = prepare_tensor_and_compute_loss(b, c, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+    # Test vectors at 180 degrees
+    for _ in range(20):
+        a = get_random_vector(3)
+        b = np.array(-a * (np.random.random() + 1e-3) *
+                     np.random.randint(1, 10), dtype=np.float32)
+        expected = np.array(1)
+
+        value = prepare_tensor_and_compute_loss(a, b, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+    # Test against scipy cosine distance
+    for _ in range(200):
+        a = get_random_vector(3)
+        b = get_random_vector(3)
+        # model outputs -cos(a,b), but cosine computes 1-cos(a,b)
+        expected = cosine(a, b) - 1
+
+        value = prepare_tensor_and_compute_loss(a, b, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+        value = prepare_packedsequence_and_compute_loss(a, b, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+
+def test_l2regression_loss():
+    np.random.seed(1234)
+    model = L2RegressionDirectionGetter(1)
+
+    # Test for x == y
+    a = get_random_vector(3)
+    b = a
+    expected = np.array(0)
+    value = prepare_tensor_and_compute_loss(a, b, model)
+    assert np.allclose(value, expected, atol=tol),\
+        "Failed; got: {}; expected: {}".format(value, expected)
+
+    # Test for random vector, compared to scipy's euclidean
+    for _ in range(200):
+        a = get_random_vector(3)
+        b = get_random_vector(3)
+        expected = euclidean(a, b)
+        value = prepare_tensor_and_compute_loss(a, b, model)
+        assert np.allclose(value, expected, atol=tol),\
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+        value = prepare_packedsequence_and_compute_loss(a, b, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+
+def test_sphere_classification_loss():
+    model = SphereClassificationDirectionGetter(1)
+    sphere = get_sphere('symmetric724')
+
+    # exactly the right class (#1)
+    # Note. To be realistic:
+    # With as many classes (724), the value of the output must be very
+    # high to have a low loss. The outputs (logits) don't have to be
+    # probabilities, as a softmax will be applied by torch.
+    logit = np.zeros((1, 724)).astype('float32')
+    logit[0, 1] = 100
+    b = sphere.vertices[1]
+    expected = -np.log(softmax(logit))[0, 1]
+    value = prepare_tensor_and_compute_loss(logit, b, model)
+    assert np.allclose(value, expected, atol=tol), \
+        "Failed; got: {}; expected: {}".format(value, expected)
+
+    # Modifying just a little the target (#1)
+    logit = np.zeros((1, 724)).astype('float32')
+    logit[0, 1] = 1
+    eps = 1e-3
+    b = sphere.vertices[1] + eps
+    expected = -np.log(softmax(logit))[0, 1]
+    value = prepare_tensor_and_compute_loss(logit, b, model)
+    assert np.allclose(value, expected, atol=tol), \
+        "Failed; got: {}; expected: {}".format(value, expected)
+
+    # Modifying the logit output (still #1 the highest)
+    logit = np.random.rand(1, 724).astype('float32')
+    logit[0, 1] = 1
+    b = sphere.vertices[1]
+    expected = -np.log(softmax(logit))[0, 1]
+    value = prepare_tensor_and_compute_loss(logit, b, model)
+    assert np.allclose(value, expected, atol=tol), \
+        "Failed; got: {}; expected: {}".format(value, expected)
+
+    # Random logits
+    logit = np.random.rand(1, 724).astype('float32')
+    b = sphere.vertices[1]
+    expected = -np.log(softmax(logit))[0, 1]
+    value = prepare_tensor_and_compute_loss(logit, b, model)
+    assert np.allclose(value, expected, atol=tol), \
+        "Failed; got: {}; expected: {}".format(value, expected)
+
+
+def test_gaussian_loss():
+    np.random.seed(1234)
+    model = SingleGaussianDirectionGetter(1)
+
+    # Test x == \mu
+    for _ in range(20):
+        a_means = get_random_vector(3)
+        a_sigmas = np.exp(get_random_vector(3))
+        b = a_means
+
+        # expected: x-mu = 0 ==> mahalanobis = 0
+        expected = -(-3 / 2 * np.log(2 * np.pi) - np.log(np.prod(a_sigmas)))
+
+        value = prepare_tensor_and_compute_loss((a_means, a_sigmas), b, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+    # Random tests
+    for _ in range(200):
+        a_means = get_random_vector(3)
+        a_sigmas = np.exp(get_random_vector(3))
+        b = get_random_vector(3)
+
+        # Manual logpdf computation
+        logpdf = independent_gaussian_log_prob_vector(b, a_means, a_sigmas)
+        expected = -logpdf
+
+        value = prepare_tensor_and_compute_loss((a_means, a_sigmas), b, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+        value = prepare_packedsequence_and_compute_loss((a_means, a_sigmas),
+                                                        b, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+
+def test_mixture_loss():
+    np.random.seed(1234)
+    model = GaussianMixtureDirectionGetter(1)
+
+    # Test against scipy
+    for _ in range(200):
+        # 3 Gaussians * (1 mixture param + 3 means + 3 variances)
+        # (no correlations)
+        a_mixture_logits = get_random_vector(3)
+        a_means = get_random_vector(3 * 3).reshape((3, 3))
+        a_sigmas = np.exp(get_random_vector(3 * 3)).reshape((3, 3))
+        b = get_random_vector(3)
+
+        # Manual logpdf computation
+        mixture_params = softmax(a_mixture_logits)
+        logpdfs = np.array([independent_gaussian_log_prob_vector(b, a_means[i],
+                                                                 a_sigmas[i])
+                            for i in range(3)])
+        expected = -logsumexp(np.log(mixture_params) + logpdfs)
+
+        value = prepare_tensor_and_compute_loss(
+            (a_mixture_logits, a_means, a_sigmas), b, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+        value = prepare_packedsequence_and_compute_loss(
+            (a_mixture_logits, a_means, a_sigmas), b, model)
+        assert np.allclose(value, expected, atol=tol), \
+            "Failed; got: {}; expected: {}".format(value, expected)
+
+
+def test_fisher_von_mises():
+    model = FisherVonMisesDirectionGetter(1)
+
+    # Test x == \mu
+    a_means = get_random_vector(3)
+    a_kappa = np.exp(get_random_vector(1))
+    b = a_means
+
+    expected = -fisher_von_mises_log_prob_vector(a_means, a_kappa, b)
+    value = prepare_tensor_and_compute_loss((a_means, a_kappa), b, model)
+    assert np.allclose(value, expected, atol=tol), \
+        "Failed; got: {}; expected: {}".format(value, expected)
+
+    # Test random
+    a_means = get_random_vector(3)
+    a_kappa = np.exp(get_random_vector(1))
+    b = get_random_vector(3)
+
+    expected = -fisher_von_mises_log_prob_vector(a_means, a_kappa, b)
+    value = prepare_tensor_and_compute_loss((a_means, a_kappa), b, model)
+    assert np.allclose(value, expected, atol=tol), \
+        "Failed; got: {}; expected: {}".format(value, expected)
+
+
+if __name__ == '__main__':
+
+    print('Testing cosine regression loss')
+    test_cosine_regression_loss()
+
+    print('Testing l2 regression loss')
+    test_l2regression_loss()
+
+    print('Testing sphere classification loss')
+    test_sphere_classification_loss()
+
+    print('Testing gaussian loss')
+    test_gaussian_loss()
+
+    print('Testing mixture loss')
+    test_mixture_loss()
+
+    print('Testing fisher-Von mises loss')
+    test_fisher_von_mises()


### PR DESCRIPTION
## Description
Philippe had done a good job last year of cleaning the "output models" but I reverified all the formulas, and added tests.

More important changes:
- I copied tests from Philippe's repo and added more for missing models (sphere class and fisher von mises)
- Gaussian mixture: name of variable was variance but base on formula, it really is sigma, the standard deviation +there was a wrong variable name used (self.layers_mixture, new line 471)

Other details:
- I moved computation of the log prob to utils to have more place for a complete doc and formulas, reviewed all formulas.
- Doc talked about the "100 points" of the sphere but it is actually 724.
- Modified some doc to fit pep8. Changed torch.tensor to tensor to save a lot of space.
- I noticed that torch is missing from requirements
- I renamed the "output_models" as "direction_getter_models" to avoid possible confusion on the term output.
- Code to create a 2-layer NN was repeated a lot, I moved it to a separate function.
