### PR TITLE
Allowing more than one streamline group

### DIFF
--- a/doc/creating_hdf5.rst
+++ b/doc/creating_hdf5.rst
@@ -23,15 +23,17 @@ Expected json config for the groups in your hdf5:
             "files": ["dwi/dwi_tractoflow.nii.gz", "anat/t1_tractoflow.nii.gz"]
              },
         "group2": {
-            ...
+            "type": "streamlines",
+            "files": ["bundles/bundle1.trk", "bundles/bundle2.trk"]
              }
     }
 
-The group names could be 'input_volume', 'target_volume', 'target_directions', or anything. Make sure your training scripts and your model'sbatch_sampler use the same keys. The groups 'files' must exist in every subject folder inside dwi_ml_ready. The groups 'type' must be recognized in dwi_ml. Currently, accepted datatype is:
+The group names could be 'input_volume', 'target_volume', 'target_directions', or anything. Make sure your training scripts and your model's batch_sampler use the same keys. The groups 'files' must exist in every subject folder inside dwi_ml_ready. The groups 'type' must be recognized in dwi_ml. Currently, accepted datatype are:
 
     - 'volume': for instance, a dwi, an anat, mask, t1, fa, etc.
+    - 'streamlines': for instance, a .trk, .tck file (anything accepted by Dipy's Stateful Tractogram).
 
-Currently, only one group of streamlines is accepted for your data, and thus the streamlines are not integreated in the config file but are considered separately. During the data creation, see the option --bundles.
+The bundles from each group of streamlines will be concatenated in the hdf5. If no bundles are present ("files": []), we will use all files in the 'bundles' folder.
 
 Creating the hdf5
 *****************

--- a/dwi_ml/data/dataset/data_lists.py
+++ b/dwi_ml/data/dataset/data_lists.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from typing import List
 
 from dwi_ml.data.dataset.single_subject_containers import (SubjectDataAbstract,
                                                            SubjectData,
@@ -20,7 +21,6 @@ class DataListForTorchAbstract(object):
         # Others must fit.
         self.feature_sizes = []  # type: List[int]
         self.volume_groups = []  # type: List[str]
-        self.streamline_group = None  # type : str
 
     def _set_feature_sizes(self, log):
         """

--- a/dwi_ml/data/dataset/multi_subject_containers.py
+++ b/dwi_ml/data/dataset/multi_subject_containers.py
@@ -82,11 +82,11 @@ class MultiSubjectDatasetAbstract(Dataset):
         # type will be dwi_ml.data.dataset.data_list.DataListForTorch or,
         # in lazy version, LazyDataListForTorch
         self.data_list = None
-        self.volume_groups = None
-        self.streamline_groups = None
-        self.streamline_id_slice_per_subj = None
-        self.total_streamlines = None
-        self.streamline_lengths_mm = None
+        self.volume_groups = [str]
+        self.streamline_groups = [str]
+        self.streamline_ids_per_subj = [slice]
+        self.total_streamlines = [int]
+        self.streamline_lengths_mm = [list]
 
     @property
     def attributes(self) -> Dict[str, Any]:
@@ -153,7 +153,7 @@ class MultiSubjectDatasetAbstract(Dataset):
 
             # Build empty data_list (lazy or not) and initialize values
             self.data_list = self._build_data_list(hdf_file)
-            self.streamline_id_slice_per_subj = \
+            self.streamline_ids_per_subj = \
                 [defaultdict(slice) for _ in self.streamline_groups]
             self.total_streamlines = [0 for _ in self.streamline_groups]
             streamline_lengths_mm_list = [[] for _ in self.streamline_groups]
@@ -212,7 +212,7 @@ class MultiSubjectDatasetAbstract(Dataset):
                        .format(n_streamlines))
 
         # Assigning these id in the dict for this group
-        self.streamline_id_slice_per_subj[group_idx][subj_idx] = \
+        self.streamline_ids_per_subj[group_idx][subj_idx] = \
             slice(self.total_streamlines[group_idx],
                   self.total_streamlines[group_idx] + n_streamlines)
 
@@ -247,9 +247,6 @@ class MultiSubjectDatasetAbstract(Dataset):
         """Note. Device is not important for non-lazy version but keeping the
         same signature"""
         raise NotImplementedError
-
-    def __len__(self):
-        return self.total_streamlines
 
     def __getitem__(self, idx: Tuple[int, int]):
         """

--- a/dwi_ml/data/dataset/streamline_containers.py
+++ b/dwi_ml/data/dataset/streamline_containers.py
@@ -53,7 +53,6 @@ class LazyStreamlinesGetter(object):
     def __getitem__(self, item):
         """
         Gets the streamlines from ids 'item', all concatenated together.
-        Still useful? See the get_array_sequence instead.
         """
         if isinstance(item, int):
             return self._get_one_streamline(item)
@@ -163,6 +162,7 @@ class SFTDataAbstract(object):
         self.space = space
         self.streamlines = streamlines
 
+    @property
     def space_attributes_as_tensor(self):
         (a, d, vs, vo) = self.space_attributes
 
@@ -205,10 +205,6 @@ class SFTData(SFTDataAbstract):
         # Return an instance of SubjectMRIData instantiated through __init__
         # with this loaded data:
         return cls(streamlines, space_attributes, space)
-
-    @property
-    def streamlines_as_tensor(self):
-        raise NotImplementedError
 
     def from_chosen_streamlines(self, streamline_ids=None):
         if streamline_ids is not None:

--- a/dwi_ml/model/batch_samplers.py
+++ b/dwi_ml/model/batch_samplers.py
@@ -444,12 +444,12 @@ class BatchStreamlinesSampler(Sampler):
                         if self.step_size:
                             # batch_size is in mm.
                             sample_heaviness = \
-                                subj_data.sft_data.streamlines.lengths_mm[
+                                subj_data.sft_data_list.streamlines.lengths_mm[
                                     subj_chosen_global_ids]
                         else:
                             # batch size in in number of points
                             sample_heaviness = \
-                                subj_data.sft_data.streamlines.lengths[
+                                subj_data.sft_data_list.streamlines.lengths[
                                     subj_chosen_global_ids]
 
                         # If batch_size has been passed, taking a little less
@@ -589,7 +589,7 @@ class BatchStreamlinesSampler(Sampler):
             subj_data = self.data_source.get_subject_data(subj)
 
             # Get streamlines as sft
-            sft = subj_data.sft_data.from_chosen_streamlines(s_ids)
+            sft = subj_data.sft_data_list.from_chosen_streamlines(s_ids)
 
             # Resampling streamlines to a fixed step size
             self.log.debug("            Resampling (if True)")

--- a/dwi_ml/model/batch_samplers.py
+++ b/dwi_ml/model/batch_samplers.py
@@ -114,9 +114,8 @@ class BatchStreamlinesSampler(Sampler):
         data_source : MultiSubjectDataset or LazyMultiSubjectDataset
             Dataset to sample from.
         streamline_group_name: str
-            The name of the group to use to load the sequences. Probably
-            'streamlines'. Should exist for all subjects in the
-            MultiSubjectData.
+            The name of the group to use to load the sequences among all
+            streamline_groups in the data_source.
         batch_size : int
             Number of required points in a batch. This will be approximated as
             the final batch size depends on data augmentation (streamline
@@ -216,6 +215,10 @@ class BatchStreamlinesSampler(Sampler):
         self.step_size = step_size
         self.avoid_cpu_computations = avoid_cpu_computations
         self.normalize_directions = normalize_directions
+
+        # Find idx of streamline group
+        self.streamline_group = self.data_source.streamline_groups.index(
+            self.streamline_group_name)
 
         # Set device
         if avoid_cpu_computations and torch.cuda.is_available():
@@ -340,7 +343,10 @@ class BatchStreamlinesSampler(Sampler):
             tractogram).
         """
         # This is the list of all possible streamline ids
-        global_streamlines_ids = np.arange(len(self.data_source))
+        global_streamlines_ids = np.arange(
+            self.data_source.total_streamlines[self.streamline_group])
+        ids_per_subjs = \
+            self.data_source.streamline_ids_per_subj[self.streamline_group]
 
         # This contains one bool per streamline:
         #   1 = this streamline has not been used yet.
@@ -356,8 +362,7 @@ class BatchStreamlinesSampler(Sampler):
             # Weight subjects by their number of remaining streamlines
             streamlines_per_subj = np.array(
                 [np.sum(global_unused_streamlines[subj_id_slice])
-                 for _, subj_id_slice in
-                 self.data_source.streamline_id_slice_per_subj.items()])
+                 for _, subj_id_slice in ids_per_subjs.items()])
             assert (np.sum(streamlines_per_subj) ==
                     np.sum(global_unused_streamlines)), \
                 "Unexpected error, the total number of streamlines per " \
@@ -384,8 +389,7 @@ class BatchStreamlinesSampler(Sampler):
                     size=n_subjects, replace=False, p=weights)
             else:
                 # Sampling from all subjects
-                sampled_subjs = \
-                    self.data_source.streamline_id_slice_per_subj.keys()
+                sampled_subjs = ids_per_subjs.keys()
                 n_subjects = len(sampled_subjs)
             self.log.debug('    Sampled subjects for this batch: {}'
                            .format(sampled_subjs))
@@ -414,8 +418,7 @@ class BatchStreamlinesSampler(Sampler):
                 for subj in sampled_subjs:
                     # Get the global streamline ids corresponding to this
                     # subject
-                    subj_id_slice = \
-                        self.data_source.streamline_id_slice_per_subj[subj]
+                    subj_id_slice = ids_per_subjs[subj]
 
                     # We will continue iterating on this subject until we
                     # break (i.e. when we reach the maximum batch size for this
@@ -425,7 +428,7 @@ class BatchStreamlinesSampler(Sampler):
                         # Find streamlines that have not been used yet.
                         subj_unused_ids_in_global = np.flatnonzero(
                             global_unused_streamlines[subj_id_slice]) + \
-                            subj_id_slice.start
+                                                    subj_id_slice.start
 
                         self.log.debug("    Available streamlines for this "
                                        "subject: {}"
@@ -441,15 +444,17 @@ class BatchStreamlinesSampler(Sampler):
                             subj_unused_ids_in_global, CHUNK_SIZE)
 
                         subj_data = self.data_source.get_subject_data(subj)
+                        subj_sft_data = \
+                            subj_data.sft_data_list[self.streamline_group]
                         if self.step_size:
                             # batch_size is in mm.
                             sample_heaviness = \
-                                subj_data.sft_data_list.streamlines.lengths_mm[
+                                subj_sft_data.streamlines.lengths_mm[
                                     subj_chosen_global_ids]
                         else:
                             # batch size in in number of points
                             sample_heaviness = \
-                                subj_data.sft_data_list.streamlines.lengths[
+                                subj_sft_data.streamlines.lengths[
                                     subj_chosen_global_ids]
 
                         # If batch_size has been passed, taking a little less
@@ -544,6 +549,8 @@ class BatchStreamlinesSampler(Sampler):
             self.streamlines_data_preparation(streamline_ids_per_subj)
 
         if self.avoid_cpu_computations:
+            self.log.debug("            Not computing directions because user "
+                           "prefers to do it later on GPU.")
             return batch_streamlines, final_s_ids_per_subj
         else:
             directions = self.compute_and_normalize_directions(
@@ -570,29 +577,31 @@ class BatchStreamlinesSampler(Sampler):
         -------
         batch_streamlines: List[np.array]
             The new streamlines after data augmentation
-        final_streamline_ids_per_subj: Dict[int, slice]
+        final_s_ids_per_subj: Dict[int, slice]
             The new streamline ids per subj in this augmented batch.
         """
-
-        self.log.debug("        Processing data preparation for streamlines "
-                       "{}:".format(streamline_ids_per_subj))
 
         # The batch's streamline ids will change throughout processing because
         # of data augmentation, so we need to do it subject by subject to
         # keep track of the streamline ids. These final ids will correspond to
         # the loaded, processed streamlines, not to the ids in the hdf5 file.
-        final_streamline_ids_per_subj = defaultdict(slice)
+        final_s_ids_per_subj = defaultdict(slice)
         batch_streamlines = []
         for subj, s_ids in streamline_ids_per_subj:
             self.log.debug("        => Subj: {}".format(subj))
 
+            self.log.debug(
+                "          Processing data preparation for streamlines ids:\n"
+                "{}".format(s_ids))
+
             subj_data = self.data_source.get_subject_data(subj)
+            subj_sft_data = subj_data.sft_data_list[self.streamline_group]
 
             # Get streamlines as sft
-            sft = subj_data.sft_data_list.from_chosen_streamlines(s_ids)
+            sft = subj_sft_data.from_chosen_streamlines(s_ids)
 
             # Resampling streamlines to a fixed step size
-            self.log.debug("            Resampling (if True)")
+            self.log.debug("            Resampling: {}".format(self.step_size))
             if self.step_size:
                 # Note that we could skip resampling if it had already the same
                 # step size, but computing current step size is not straight-
@@ -606,8 +615,10 @@ class BatchStreamlinesSampler(Sampler):
             # Adding noise to coordinates
             # Noise is considered in mm so we need to make sure the sft is in
             # rasmm space
-            self.log.debug("            Adding noise (if True)")
-            if self.noise_gaussian_size and self.noise_gaussian_size > 0:
+            add_noise = bool(self.noise_gaussian_size and
+                             self.noise_gaussian_size > 0)
+            self.log.debug("            Adding noise: {}".format(add_noise))
+            if add_noise:
                 sft.to_rasmm()
                 sft = add_noise_to_streamlines(sft,
                                                self.noise_gaussian_size,
@@ -617,8 +628,9 @@ class BatchStreamlinesSampler(Sampler):
             # Splitting streamlines
             # This increases the batch size, but does not change the total
             # length
-            self.log.debug("            Splitting (if True)")
-            if self.split_ratio and self.split_ratio > 0:
+            do_split = bool(self.split_ratio and self.split_ratio > 0)
+            self.log.debug("            Splitting: {}".format(do_split))
+            if do_split:
                 all_ids = np.arange(len(sft))
                 n_to_split = int(np.floor(len(sft) * self.split_ratio))
                 split_ids = self.np_rng.choice(all_ids, size=n_to_split,
@@ -626,8 +638,9 @@ class BatchStreamlinesSampler(Sampler):
                 sft = split_streamlines(sft, self.np_rng, split_ids)
 
             # Reversing streamlines
-            self.log.debug("            Reversing (if True)")
-            if self.reverse_ratio and self.reverse_ratio > 0:
+            do_reverse = self.reverse_ratio and self.reverse_ratio > 0
+            self.log.debug("            Reversing: {}".format(do_reverse))
+            if do_reverse:
                 ids = np.arange(len(sft))
                 self.np_rng.shuffle(ids)
                 reverse_ids = ids[:int(len(ids) * self.reverse_ratio)]
@@ -639,7 +652,7 @@ class BatchStreamlinesSampler(Sampler):
             # Remember the indices of this subject's (augmented) streamlines
             ids_start = len(batch_streamlines)
             ids_end = ids_start + len(sft)
-            final_streamline_ids_per_subj[subj] = slice(ids_start, ids_end)
+            final_s_ids_per_subj[subj] = slice(ids_start, ids_end)
 
             # Add all (augmented) streamlines to the batch
             # What we want is the streamline coordinates, to eventually get
@@ -647,7 +660,7 @@ class BatchStreamlinesSampler(Sampler):
             sft.to_vox()
             batch_streamlines.extend(sft.streamlines)
 
-            return batch_streamlines, final_streamline_ids_per_subj
+            return batch_streamlines, final_s_ids_per_subj
 
     def project_specific_data_augmentation(self, sft: StatefulTractogram):
         """Please override in your child class if you want to do more than
@@ -669,8 +682,7 @@ class BatchStreamlinesSampler(Sampler):
             - Computing the directions from streamlines coordinates
             - Normalization of the directions.
         """
-        self.log.debug("            Computing and normalizing directions "
-                       "(if True)")
+        self.log.debug("            Computing and normalizing directions ")
 
         # Getting directions
         batch_directions = [torch.as_tensor(s[1:] - s[:-1],

--- a/dwi_ml/model/batch_samplers.py
+++ b/dwi_ml/model/batch_samplers.py
@@ -750,8 +750,6 @@ class BatchStreamlinesSampler1IPV(BatchStreamlinesSampler):
         self.input_group_name = input_group_name
 
         # Find group index in the data_source
-        # Returns the first appearance.
-        # toDo If the group is present twice, no error. ok?
         idx = self.data_source.volume_groups.index(input_group_name)
         self.input_group_idx = idx
 

--- a/dwi_ml/training/checks_for_experiment_parameters.py
+++ b/dwi_ml/training/checks_for_experiment_parameters.py
@@ -266,9 +266,11 @@ def check_all_experiment_parameters(conf: dict):
         conf['data_augmentation']['reverse_ratio'])
 
     # Input:
-    all_params['neighborhood_type, neighborhood_radius'] = check_neighborhood(
+    (n_type, n_radius) = check_neighborhood(
         conf['input']['neighborhood']['sphere_radius'],
         conf['input']['neighborhood']['grid_radius'])
+    all_params['neighborhood_type'] = n_type
+    all_params['neighborhood_radius'] = n_radius
     all_params['num_previous_dirs'] = check_previous_dir(
         conf['input']['num_previous_dirs'])
 

--- a/please_copy_and_adapt/config_file_example.json
+++ b/please_copy_and_adapt/config_file_example.json
@@ -1,0 +1,12 @@
+
+{
+    "input": {
+        "type": "volume",
+       	"files": ["dwi/dwi_tractoflow.nii.gz", "anat/t1_tractoflow.nii.gz"]
+	     },
+
+    "streamlines": {
+        "type": "streamlines",
+        "files": ["bundles/tractoflow__interface_pft_tracking_wholebrain.trk"]
+    }
+}

--- a/please_copy_and_adapt/train_model.py
+++ b/please_copy_and_adapt/train_model.py
@@ -26,6 +26,7 @@ from dwi_ml.model.main_models import MainModelAbstract
 from dwi_ml.training.checks_for_experiment_parameters import (
     check_all_experiment_parameters)
 from dwi_ml.training.trainers import (DWIMLTrainer)
+from dwi_ml.utils import format_dict_to_str
 
 # These are model-dependant. Choose the best classes and functions for you
 # 1. Change this init_dataset function if you prefer! This loads either a
@@ -35,8 +36,6 @@ from dwi_ml.data.dataset.multi_subject_containers import init_dataset
 #    This is one possibility, others could be implemented.
 from dwi_ml.model.batch_samplers import (
     BatchStreamlinesSampler1IPV as ChosenBatchSampler)
-
-
 # 3. Implement the build_model function below
 
 
@@ -46,6 +45,14 @@ def parse_args():
     p.add_argument('experiment_path',
                    help='Path where to save your experiment. Complete path '
                         'will be experiment_path/experiment_name.')
+    p.add_argument('--input_group',
+                   help='Name of the input group. If a checkpoint exists, '
+                        'this information is already contained in the '
+                        'checkpoint and is not necessary.')
+    p.add_argument('--target_group',
+                   help='Name of the target streamline group. If a checkpoint '
+                        'exists, this information is already contained in the '
+                        'checkpoint and is not necessary.')
     p.add_argument('--hdf5_filename',
                    help='Path to the .hdf5 dataset. Should contain both your '
                         'training subjects and validation subjects. If a '
@@ -92,12 +99,10 @@ def prepare_data_and_model(train_data_params, valid_data_params,
     with Timer("\n\nPreparing batch samplers with volume: {}"
                .format(training_dataset.volume_groups[0]),
                newline=True, color='green'):
-        training_batch_sampler = ChosenBatchSampler(
-            training_dataset, training_dataset.streamline_group,
-            training_dataset.volume_groups[0], **train_sampler_params)
-        validation_batch_sampler = ChosenBatchSampler(
-            validation_dataset, validation_dataset.streamline_group,
-            validation_dataset.volume_groups[0], **valid_sampler_params)
+        training_batch_sampler = ChosenBatchSampler(training_dataset,
+                                                    **train_sampler_params)
+        validation_batch_sampler = ChosenBatchSampler(validation_dataset,
+                                                      **valid_sampler_params)
 
     # Instantiate model.
     # Hint: input_size is :
@@ -181,20 +186,27 @@ def main():
         all_params['experiment_path'] = args.experiment_path
         all_params['experiment_name'] = args.experiment_name
 
+        logging.debug("All params: " + format_dict_to_str(all_params))
+
         train_params = all_params.copy()
         train_params['subjs_set'] = 'training_subjs'
         valid_params = all_params.copy()
         valid_params['subjs_set'] = 'validation_subjs'
 
+        # If you wish to have different parameters for the batch sampler during
+        # trainnig and validation, change values below.
+        sampler_params = all_params.copy()
+        sampler_params['input_group_name'] = args.input_group
+        sampler_params['streamline_group_name'] = args.target_group
+
         # Prepare the trainer from checkpoint_state
         (training_batch_sampler, validation_batch_sampler,
          model) = prepare_data_and_model(train_params, valid_params,
-                                         all_params, all_params,
+                                         sampler_params, sampler_params,
                                          None)
 
         # Instantiate trainer
-        with Timer("\n\nPreparing trainer",
-                   newline=True, color='red'):
+        with Timer("\n\nPreparing trainer", newline=True, color='red'):
             trainer = DWIMLTrainer(training_batch_sampler,
                                    validation_batch_sampler, model,
                                    **all_params)

--- a/please_copy_and_adapt/training_parameters.yaml
+++ b/please_copy_and_adapt/training_parameters.yaml
@@ -123,7 +123,7 @@ memory:
   avoid_cpu_computations: True
   # num_cpu_workers: int
   #     Number of parallel CPU workers.
-  num_cpu_workers: 1
+  num_cpu_workers: 0
   # worker_interpolation: bool
   #     If set, if using num_cpu_workers > 0, interpolation will be done on CPU
   #     by the workers instead of on the main thread using the chosen device.

--- a/tests/running_tests.sh
+++ b/tests/running_tests.sh
@@ -65,7 +65,8 @@ rm $test_tractograms_path/test_batch1*
 # Further testing was done with Learn2track's model.
 ###########
 mkdir $database_folder/experiments
-python please_copy_and_adapt/train_model.py --loggin debug \
+python please_copy_and_adapt/train_model.py --logging debug \
+      --input_group 'input' --target_group 'streamlines' \
       --hdf5_filename $database_folder/hdf5/ismrm2015_noArtefact_test.hdf5 \
       --parameters_filename please_copy_and_adapt/training_parameters.yaml \
       --experiment_name test_experiment1 $database_folder/experiments

--- a/tests/running_tests.sh
+++ b/tests/running_tests.sh
@@ -24,30 +24,22 @@ $organize_from_tractoflow_folder/organize_from_tractoflow.sh $database_folder $s
 # Create hdf5
 ###########
 name=ismrm2015_noArtefact_test
-bundle=tractoflow__interface_pft_tracking_wholebrain
 logging="info"
 mask_for_standardization="masks/b0_bet_mask_resampled.nii.gz"
 space="rasmm"
 step_size=0.5 #Use step_size for now. Dipy's compress_streamlines seems to have memory issues.
 training_subjs="$database_folder/subjects_for_ML_training.txt"
 validation_subjs="$database_folder/subjects_for_ML_validation.txt"
-config_file="$database_folder/config_file.json"
+config_file="please_copy_and_adapt/config_file_example.json"
 
 echo ismrm2015_noArtefact > $training_subjs
 echo fake_subj2 > $validation_subjs
 cp -r $database_folder/dwi_ml_ready/ismrm2015_noArtefact/ $database_folder/dwi_ml_ready/fake_subj2
-# My config file is:
-#{
-#    "input": {
-#	        "type": "volume",
-#       	"files": ["dwi/dwi_tractoflow.nii.gz", "anat/t1_tractoflow.nii.gz", "anat/t1_tractoflow.nii.gz", "anat/t1_tractoflow.nii.gz"]
-#	     }
-#}
 
 create_hdf5_dataset.py --force --name $name --save_intermediate \
         --std_mask $mask_for_standardization --independent_modalities True \
-        --bundles $bundle --logging $logging --space $space \
-        --enforce_bundles_presence True --step_size $step_size \
+        --logging $logging --space $space \
+        --enforce_files_presence True --step_size $step_size \
         $database_folder $config_file $training_subjs $validation_subjs
 
 ###########

--- a/tests/test_batch_sampler_iter.py
+++ b/tests/test_batch_sampler_iter.py
@@ -4,7 +4,6 @@ from argparse import RawTextHelpFormatter
 import logging
 from os import path
 
-import numpy as np
 from torch.utils.data.dataloader import DataLoader
 
 from dwi_ml.data.dataset.multi_subject_containers import (

--- a/tests/test_multisubjectdataset_creation_from_hdf5.py
+++ b/tests/test_multisubjectdataset_creation_from_hdf5.py
@@ -4,8 +4,6 @@ from argparse import RawTextHelpFormatter
 import logging
 from os import path
 
-import numpy as np
-
 from dwi_ml.data.dataset.multi_subject_containers import (
     LazyMultiSubjectDataset, MultiSubjectDataset)
 
@@ -25,7 +23,7 @@ def parse_args():
 
 
 def test_non_lazy():
-    print("**========= NON-LAZY =========")
+    print("\n\n**========= NON-LAZY =========\n\n")
     fake_dataset = MultiSubjectDataset(args.hdf5_filename, 'training_subjs')
     fake_dataset.load_data()
     print("**Created a MultiSubjectDataset and loaded training set. "
@@ -44,10 +42,10 @@ def test_non_lazy():
           "        First streamline as sft: {} \n"
           .format(subj0, subj0.subject_id, subj0.volume_groups,
                   subj0.mri_data_list, subj0.mri_data_list[0]._data.shape,
-                  subj0.streamline_group,
-                  len(subj0.sft_data.streamlines),
-                  subj0.sft_data.streamlines[0][0],
-                  subj0.sft_data.from_chosen_streamlines(0).streamlines[0][0]))
+                  subj0.streamline_groups,
+                  len(subj0.sft_data_list[0].streamlines),
+                  subj0.sft_data_list[0].streamlines[0][0],
+                  subj0.sft_data_list[0].from_chosen_streamlines(0).streamlines[0][0]))
 
     subj0_volume0_tensor = fake_dataset.get_subject_mri_group_as_tensor(0, 0)
     print("**Get_subject_mri_data_as_tensor from subject 0, volume 0: \n"
@@ -81,9 +79,9 @@ def test_lazy():
           .format(subj0, subj0.hdf_handle, subj0.subject_id,
                   subj0.volume_groups,
                   subj0.mri_data_list, subj0.mri_data_list[0]._data,
-                  subj0.streamline_group, subj0.sft_data.streamlines,
-                  subj0.sft_data.streamlines.get_array_sequence()[0][0],
-                  subj0.sft_data.from_chosen_streamlines(0).streamlines[0][0]))
+                  subj0.streamline_groups, subj0.sft_data_list[0].streamlines,
+                  subj0.sft_data_list[0].streamlines[0][0],
+                  subj0.sft_data_list[0].from_chosen_streamlines(0).streamlines[0][0]))
 
     subj0_volume0_tensor = fake_dataset.get_subject_mri_group_as_tensor(0, 0)
     print("**Get_subject_mri_data_as_tensor: subject 0, volume 0. \n"
@@ -101,7 +99,7 @@ if __name__ == '__main__':
         raise ValueError("The hdf5 file ({}) was not found!"
                          .format(args.hdf5_filename))
 
-    logging.basicConfig(level='INFO')
+    logging.basicConfig(level='DEBUG')
 
     test_non_lazy()
     print('\n\n')


### PR DESCRIPTION
## Description

Changed the dataset creation to take the bundles name from the config_file, same as for the inputs. Also allowing more than one streamline group (ex, you could have your model use 'good examples' and 'bad examples' of streamlines). Changes are made in the multisubject containers, the batch sampler and the training.

## Testing data and script
All existing tests have been re-verified.
