### PR TITLE
Merging training validation

### DIFF
--- a/doc/data_containers.rst
+++ b/doc/data_containers.rst
@@ -1,0 +1,120 @@
+
+About our data containers
+=========================
+
+Here is our data is organized to allow torch to use them through Dataloaders. All of the following can be used as lazy instead. Then, the data is only loaded when needed.
+
+
+**(Lazy)MultisubjectDataset**
+
+    subcontainers:
+
+        .training_set: **Multisubjectsubset**
+
+        .validation_set: **Multisubjectsubset**
+
+    other attributes:
+
+        .groups, .volume_groups, .streamline_group, .hdf5_path, .name: general attributes found in the hdf5 file.
+
+    methods:
+
+        *.load_data()*: loads the training and validation sets.
+
+
+**Multisubjectsubset**
+
+    subcontainers:
+
+        .subjects_data_list: **SubjectsDataList**
+
+    other attributes:
+
+        .volume_groups, .streamline_group, .hdf5_path, .set_name: general attributes found in the hdf5 file.
+
+        .cache_size
+
+        .streamline_id_slice_per_subj, .total_streamlines, .streamline_length_mm: attributes used by the batch sampler to access specific streamlines.
+
+    methods:
+
+        *.get_volume()*: gets a specific mri volume (ID corresponds to the group ID in the config_file) from a specific subject.
+
+        *.get_volume_verify_cache()*: same, but if data was lazy, checks the volume cache first. If it was not cached, loads it and sends it to the cache.
+
+        *.__getitem__()*: used by the dataloader. Does not do anything per say, simply returns the sampled streamline id. The batch sampler will do the job of actually loading the data.
+
+
+**(Lazy)SubjectsDataList**
+
+    subcontainers:
+
+        ._subjects_data_list: List of **SubjectData**. Hidden attributes, the List reimplements all properties to avoid its use, such as __len__ and __getitem__.
+
+    other attributes:
+
+        .volume_groups, .streamline_group, .hdf5_path: general attributes found in the hdf5 file.
+
+        .feature_sizes: list of the dimension of each volume.
+
+    methods:
+
+        *.add_subject()*: used by the MultisubjectDataset when loading the data.
+
+        *.__getitem__()*: gets a specific subject from the list. In the lazy case, returns a non-loaded subject.
+
+        *.getitem_with_handle()*: same, but in the lazy case, adds a hdf5 handle first to allow loading. You probably won't need this method: used in the get_volume() method of the MultisubjectSubset.
+
+
+**(Lazy)SubjectData**
+
+    subcontainers:
+
+        .volume_list: list of **MRIData**. In the lazy case, this actually calls a property method that will return data differently if the hdf5 handle has been added or not.
+
+        .sft_data: **SFTData**. For now, a single sft is added per subject (the created_hdf5_dataset merges all the streamlines files you want for a subject). Future work could allow a list of SFTData, for instance good examples (targets) vs bad examples. Here again, in the lazy case, this actually calls a property method.
+
+    other attributes:
+
+        .volume_groups, .streamline_group, .subject_id: general attributes found in the hdf5 file.
+
+    methods:
+
+        *.init_from_hdf()*: used by the MultisubjectDataset when loadining the data.
+
+        *.with_handle()*: useful only in the lazy case. Adds hdf_handle to the subject to allow loading.
+
+
+**MRIData**
+
+    attributes:
+
+        ._data: hidden. Depends on the internal data management (lazy or not). Acces the data through the .as_tensor() method.
+
+        .affine: loaded as a torch tensor even in the lazy case.
+
+        .shape: property method returning the shape of the data.
+
+    methods:
+
+        *.init_from_hdf_info()*: used when loadining the data.
+
+        *.as_tensor()*: gets the data.
+
+
+**SFTData**
+
+    attributes:
+
+        ._space_attributes, .space: properties from the SFT.
+
+        ._space_attributes_as_tensor: property method converting the space attributes.
+
+        .streamlines: either an ArraySequence, same as in a SFT, or, in the lazy case, a **LazyStreamlineGetter**, with can access a specific streamline from the hdf5 data without keeping the whole data in memory. It has otherwise the same properties as an ArraySequence.
+
+    methods:
+
+        *.init_from_hdf_info()*: used when loadining the data.
+
+        *.as_tensor()*: gets the data.
+

--- a/doc/processing.rst
+++ b/doc/processing.rst
@@ -11,7 +11,7 @@ When ready, you will be able to run, in order:
 
      #. ``organize_from_tractoflow.sh``
      #. ``organize_from_recobundles.sh``
-     #. ``create_dataset.sh``.
+     #. ``create_hdf5_dataset.sh``.
      #. ``training.sh``.
      #. ``tracking.sh``.
 
@@ -20,3 +20,4 @@ More information can be found below (more to come).
 .. toctree::
 
     creating_hdf5
+    data_containers

--- a/dwi_ml/data/dataset/multi_subject_containers.py
+++ b/dwi_ml/data/dataset/multi_subject_containers.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 """
 This multisubject dataset:
-    - Reads data in the given hdf5 dataset. Keys are the subjects.
-    - For each subject, keys are either:
-        - Groups to load as mri volume, with attrs 'type' = 'volume' and
-        'affine' = the affine.
-        - Streamlines to load, with attrs 'type' = 'streamlines' and with
-         datasets 'streamlines/data', 'streamlines/offsets',
-         'streamlines/lengths', 'streamlines/euclidean_lengths'.
+    - Reads data in the given hdf5 dataset.
+    - For each subset (training set, validation set):
+        - For each subject, keys are either:
+            - Groups to load as mri volume, with attrs 'type' = 'volume' and
+              'affine' = the affine.
+            - Streamlines to load, with attrs 'type' = 'streamlines' and with
+              datasets 'streamlines/data', 'streamlines/offsets',
+              'streamlines/lengths', 'streamlines/euclidean_lengths'.
 
-You can use this multisubject dataset as base for your batch sampler. Create
-it to get the data from chosen groups based on your model. See for instance
-dwi_ml.model.batch_sampler.TrainingBatchSamplerOneInputVolume.
+You can use the subsets as base for your batch sampler. Create
+it to get the data from chosen groups based on your model.
 """
 from collections import defaultdict
 from datetime import datetime
@@ -26,205 +26,54 @@ from torch.utils.data import Dataset
 import tqdm
 
 from dwi_ml.cache.cache_manager import SingleThreadCacheManager
-from dwi_ml.data.dataset.subjects_list_containers import (
-    SubjectsDataList, LazySubjectsDataList)
-from dwi_ml.data.dataset.single_subject_containers import (
-    SubjectDataAbstract, SubjectData, LazySubjectData)
 from dwi_ml.data.dataset.utils import find_groups_info
+from dwi_ml.data.dataset.subjects_list_containers import (LazySubjectsDataList,
+                                                          SubjectsDataList)
+from dwi_ml.data.dataset.single_subject_containers import (SubjectData,
+                                                           LazySubjectData)
 from dwi_ml.utils import TqdmLoggingHandler
 
 
-class MultiSubjectDatasetAbstract(Dataset):
-    """Dataset containing multiple SubjectData or LazySubjectData objects,
-    saved in a DataList or LazyDataList. Abstract class to be implemented below
-    for cases lazy or non-lazy.
+class MultisubjectSubset(Dataset):
+    """The MultiSubjectDatasets will contain two subsets: the training set
+    and the validation set."""
+    def __init__(self, set_name, hdf5_path, is_lazy: bool, log,
+                 cache_size: int = 0):
 
-    Based on torch's dataset class. Provides functions for a DataLoader to
-    iterate over data and process batches.
-    """
-    def __init__(self, hdf5_path: str, subjs_set: str, name: str = None,
-                 taskman_managed: bool = False):
-        """
-        Parameters
-        ----------
-        hdf5_path: str
-            Path to the hdf5 file containing the data.
-        subjs_set: str
-            Either 'training_subjs' or 'validation_subjs'. The subjects to
-            load when using self.load_data(). This refers to the attrs in the
-            hdf5 file containing the list of subjects for the training dataset
-            and the validation dataset.
-        name: str
-           Name of the dataset, optional.
-        taskman_managed: bool
-            Enable or disable que tqdm progress bar.
-        """
-        # Dataset info
+        self.set_name = set_name
         self.hdf5_path = hdf5_path
-        self.name = name if name else os.path.basename(self.hdf5_path)
-        self.set = subjs_set
-        if not (subjs_set == 'training_subjs' or
-                subjs_set == 'validation_subjs'):
-            raise ValueError("The MultisubjectDataset set should be either "
-                             "'training_subjs' or 'validation_subjs' but we "
-                             "received {}".format(subjs_set))
+        self._log = log
 
-        # Concerning the memory usage:
-        self.taskman_managed = taskman_managed
+        self.volume_groups = []  # type: List[str]
+        self.nb_features = []  # type: List[int]
+        self.streamline_groups = []  # type: List[str]
 
-        # Prepare log to work with tqdm. Use self.log instead of logging
-        # inside any tqdm loop
-        self.log = logging.getLogger('for_tqdm' + str(datetime.now()))
-        self.log.setLevel(logging.root.level)
-        self.log.addHandler(TqdmLoggingHandler())
-        self.log.propagate = False
+        # The subjects data list will be either a SubjectsDataList or a
+        # LazySubjectsDataList depending MultisubjectDataset.is_lazy.
+        self.subjs_list = None
 
-        # Preparing the dataset
-        # type will be dwi_ml.data.dataset.data_list.DataListForTorch or,
-        # in lazy version, LazyDataListForTorch
-        self.data_list = None
-        self.volume_groups = [str]
-        self.streamline_groups = [str]
-        self.nb_features = [int]
-        self.streamline_ids_per_subj = [slice]
-        self.total_streamlines = [int]
-        self.streamline_lengths_mm = [list]
+        # To help the batch sampler: one value per streamline group
+        self.streamline_ids_per_subj = []  # type: List[defaultdict[slice]]
+        self.total_streamlines = []  # type: List[int]
+        self.streamline_lengths_mm = []  # type: List[List[int]]
 
-        self.is_lazy = None
+        self.is_lazy = is_lazy
+
+        # This is only used in the lazy case, cache_size > 0
+        self.cache_size = cache_size
+        self._volume_cache_manager = None
 
     @property
     def attributes(self) -> Dict[str, Any]:
         all_params = {
             'hdf5_path': self.hdf5_path,
-            'name': self.name,
-            'set': self.set,
-            'taskman_managed': self.taskman_managed,
             'volume_groups': self.volume_groups,
             'nb_features': self.nb_features,
             'streamline_groups': self.streamline_groups,
-            'is_lazy': self.is_lazy
+            'is_lazy': self.is_lazy,
+            'cache_size': self.cache_size,
         }
         return all_params
-
-    def load_data(self):
-        """
-        Load raw dataset into memory.
-        """
-        with h5py.File(self.hdf5_path, 'r') as hdf_file:
-            # Load main attributes from hdf file, but each process calling
-            # the collate_fn must open its own hdf_file
-            if hdf_file.attrs["version"] < 2:
-                logging.warning("Current dwi_ml version should work with "
-                                "hdf database version >= 2. This could fail."
-                                "database version: {}"
-                                .format(hdf_file.attrs["version"]))
-
-            # Basing group names on the first subject
-            logging.debug("Loading the first subject's group information. "
-                          "Others should fit")
-            subject_keys = sorted(hdf_file.attrs[self.set])
-            self.volume_groups, self.nb_features, self.streamline_groups = \
-                find_groups_info(hdf_file, subject_keys[0], self.log)
-
-            logging.debug('hdf_file (subject) keys for the {} set '
-                          'are: {}'.format(self.set, subject_keys))
-
-            # Build empty data_list (lazy or not) and initialize values
-            self.data_list = self._build_data_list(hdf_file)
-            self.streamline_ids_per_subj = \
-                [defaultdict(slice) for _ in self.streamline_groups]
-            self.total_streamlines = [0 for _ in self.streamline_groups]
-            streamline_lengths_mm_list = [[] for _ in self.streamline_groups]
-
-            # Using tqdm progress bar, load all subjects from hdf_file
-            for subject_id in tqdm.tqdm(subject_keys, ncols=100,
-                                        disable=self.taskman_managed):
-                # Create subject's container
-                # Uses SubjectData or LazySubjectData based on the class
-                # calling this method. In the lazy case, the hdf_file is not
-                # passed so subject information will basically be empty.
-                self.log.debug('* Creating subject "{}": '.format(subject_id))
-                subj_data = self._init_subj_from_hdf(
-                    hdf_file, subject_id, self.volume_groups, self.nb_features,
-                    self.streamline_groups, self.log)
-
-                # Add subject to the list
-                subj_idx = self.data_list.add_subject(subj_data, self.log)
-
-                # Arrange streamlines
-                # In the lazy case, we need to load the data first using the
-                # __getitem__ from the datalist, and passing the hdf handle.
-                # For the non-lazy version, this does nothing.
-                subj_data = subj_data.with_handle(hdf_file)
-                for i in range(len(self.streamline_groups)):
-                    streamline_lengths_mm_list[i] = self._arrange_streamlines(
-                        subj_data, subj_idx, streamline_lengths_mm_list[i], i)
-
-                self.log.debug("* Done")
-
-        # Arrange final data properties
-        self.streamline_lengths_mm = \
-            [np.concatenate(streamline_lengths_mm_list[i], axis=0)
-             for i in range(len(self.streamline_groups))]
-
-    def _arrange_streamlines(
-            self, subj_data: Union[SubjectData, LazySubjectData],
-            subj_idx: int, group_streamline_lengths_mm_list: List,
-            group_idx: int):
-        """
-        Concatenating streamlines but remembering which id was which subject's
-        streamline.
-
-        The subj_data.streamlines depend on the class: np.Array in the non-lazy
-        version, or property in the lazy version, returning streamlines only if
-        a handle is present.
-        """
-        group = self.streamline_groups[group_idx]
-
-        self.log.debug("     => Arranging streamlines per ID for group '{}'."
-                       .format(group))
-
-        # Assign a unique ID to every streamline
-        n_streamlines = len(subj_data.sft_data_list[group_idx].streamlines)
-        self.log.debug("        Subject had {} streamlines for this group."
-                       .format(n_streamlines))
-
-        # Assigning these id in the dict for this group
-        self.streamline_ids_per_subj[group_idx][subj_idx] = \
-            slice(self.total_streamlines[group_idx],
-                  self.total_streamlines[group_idx] + n_streamlines)
-
-        # Update total nb of streamlines in the dataset for this group
-        self.total_streamlines[group_idx] += n_streamlines
-
-        # Get number of timesteps per streamline for this group
-        group_streamline_lengths_mm_list.append(
-            np.array(subj_data.sft_data_list[group_idx].streamlines.lengths_mm,
-                     dtype=np.int16))
-
-        return group_streamline_lengths_mm_list
-
-    @staticmethod
-    def _build_data_list(hdf_file):
-        raise NotImplementedError
-
-    @staticmethod
-    def _init_subj_from_hdf(hdf_file, subject_id, volume_groups, nb_features,
-                            streamline_groups, log):
-        raise NotImplementedError
-
-    """
-    The following methods will help the batch sampler to access specific data
-    """
-    def get_subject_data(self, subj_idx: int) -> SubjectDataAbstract:
-        raise NotImplementedError
-
-    def get_subject_mri_group_as_tensor(self, subj_idx: int, group_idx: int,
-                                        device: torch.device,
-                                        non_blocking: bool = False):
-        """Note. Device is not important for non-lazy version but keeping the
-        same signature"""
-        raise NotImplementedError
 
     def __getitem__(self, idx: Tuple[int, int]):
         """
@@ -241,160 +90,290 @@ class MultiSubjectDatasetAbstract(Dataset):
             It is already a (streamline_id, subj_id).
         """
         if not isinstance(idx, tuple):
-            raise ValueError("Idx ({}) was not a tuple. Please verify how "
-                             "your batch sampler created the list of idx to "
-                             "fetch.".format(idx))
+            raise ValueError("Subset: Idx ({}) was not a tuple. Please verify "
+                             "how your batch sampler created the list of idx "
+                             "to fetch.".format(idx))
         return idx
 
+    def get_volume_verify_cache(self, subj_idx: int, group_idx: int,
+                                device: torch.device = None,
+                                non_blocking: bool = False):
+        """
+        There will be one cache manager per subset. This could be moved to
+        the MultiSubjectDatasetAbstract but easier to deal with here.
 
-class MultiSubjectDataset(MultiSubjectDatasetAbstract):
-    """Dataset containing multiple SubjectData objects saved in a DataList."""
-    def __init__(self, hdf5_path: str, subjs_set: str, name: str = None,
-                 taskman_managed: bool = False):
-        super().__init__(hdf5_path, subjs_set, name, taskman_managed)
+        Loads volume as a tensor. In the case of lazy dataset, checks the cache
+        first. If data was not on the cache, loads it and sends it to the
+        cache before returning.
+        """
 
-        # This will accelerate verification of laziness, compared to
-        # is_instance(data, LazyMultiSubjectDataset)
-        self.is_lazy = False
+        # First verifiy cache (if lazy)
+        cache_key = str(subj_idx) + '.' + str(group_idx)
+        if self.subjs_list.is_lazy and self.cache_size > 0:
+            # Parallel workers each build a local cache
+            # (data is duplicated across workers, but there is no need to
+            # serialize/deserialize everything)
+            if self._volume_cache_manager is None:
+                self._volume_cache_manager = \
+                    SingleThreadCacheManager(self.cache_size)
 
-    @staticmethod
-    def _build_data_list(hdf_file):
-        """ hdf_file not used. But this is used by load, and the lazy version
-        uses this parameter. Keeping the same signature."""
-        return SubjectsDataList()
+            try:
+                # General case: Data is already cached
+                mri_data = self._volume_cache_manager[cache_key]
+                return mri_data
+            except KeyError:
+                pass
 
-    @staticmethod
-    def _init_subj_from_hdf(hdf_file, subject_id, volume_groups, nb_features,
-                            streamline_groups, log):
-        return SubjectData.init_from_hdf(
-            subject_id, log, hdf_file,
-            (volume_groups, nb_features, streamline_groups))
+        # Either non-lazy or if lazy, data was not cached.
+        mri_data = self._get_volume(subj_idx, group_idx, device, non_blocking)
 
-    def get_subject_data(self, subj_idx: int) -> SubjectData:
-        """Here, data_list is a DataListForTorch, and its elements are
-        SubjectData."""
-        return self.data_list[subj_idx]
+        if self.subjs_list.is_lazy and self.cache_size > 0:
+            # Send volume_data on cache
+            self._volume_cache_manager[cache_key] = mri_data
 
-    def get_subject_mri_group_as_tensor(self, subj_idx: int, group_idx: int,
-                                        device: torch.device = None,
-                                        non_blocking: bool = False):
-        """Different in lazy version. Here, get_subject_data is a SubjectData,
-         its mri_data is a List[SubjectMRIData], all already loaded.
-         mri_group_idx corresponds to the group number from the config_file."""
-        mri = self.get_subject_data(subj_idx).mri_data_list[group_idx]
-        volume_data = mri.as_tensor
+        return mri_data
+
+    def _get_volume(self, subj_idx: int, group_idx: int,
+                    device: torch.device = None,
+                    non_blocking: bool = False):
+        """
+        Contrary to get_volume_verify_cache, this does not send data to
+        cache for later use.
+
+        Loads volume as a tensor.
+        """
+        if self.subjs_list.is_lazy:
+            subj_data = self.subjs_list.open_handle_and_getitem(
+                subj_idx)
+        else:
+            subj_data = self.subjs_list[subj_idx]
+
+        volume_data = subj_data.mri_data_list[group_idx].as_tensor
         volume_data.to(device=device, non_blocking=non_blocking)
 
         return volume_data
 
 
-class LazyMultiSubjectDataset(MultiSubjectDatasetAbstract):
-    """Dataset containing multiple LazySubjectData objects saved in a
-    LazyDataList."""
-    def __init__(self, hdf5_path: str, subjs_set: str, name: str = None,
-                 taskman_managed: bool = False, cache_size: int = 0):
-        super().__init__(hdf5_path, subjs_set, name, taskman_managed)
+class MultiSubjectDataset:
+    """Dataset containing multiple SubjectData or LazySubjectData objects,
+    saved in a DataList or LazyDataList. Abstract class to be implemented below
+    for cases lazy or non-lazy.
 
-        # In case `None` was passed explicitly, change cache_size:
-        self.cache_size = cache_size or 0
+    Based on torch's dataset class. Provides functions for a DataLoader to
+    iterate over data and process batches.
+    """
+    def __init__(self, hdf5_filename: str, name: str = None,
+                 taskman_managed: bool = False, lazy: bool = False,
+                 cache_size: int = 0, **_):
+        """
+        Parameters
+        ----------
+        hdf5_filename: str
+            Path to the hdf5 file containing the data.
+        name: str
+           Name of the dataset, optional.
+        taskman_managed: bool
+            Enable or disable que tqdm progress bar.
+        lazy: bool
+            Use lazy or non-lazy data. Lazy data only loads data from the hdf5
+            when asked explicitely. Non-lazy loads everything at once in the
+            load_data method.
+        cache_size: int
+            Only useful with the non-lazy data. NOTE: Real cache size will
+            actually be twice this value as the training and validation subsets
+            each have their cache.
+        """
+        # Dataset info
+        self.hdf5_path = hdf5_filename
+        self.name = name if name else os.path.basename(self.hdf5_path)
 
-        # This is important. HDF5 file opening should be done in the
-        # __get_item__ method or similar, AFTER the worker sub-processes
-        # have started. This way, all sub-processes will have their own
-        # HDF handle. Otherwise, there may be data corruption because
-        # h5py is not thread-safe.
-        self.hdf_handle = None
-        if self.cache_size > 0:
-            self.volume_cache_manager = None
+        # Concerning the memory usage:
+        self.taskman_managed = taskman_managed
 
-        # This will accelerate verification of laziness, compared to
-        # is_instance(data, LazyMultiSubjectDataset)
-        self.is_lazy = True
+        # Prepare log to work with tqdm. Use self.log instead of logging
+        # inside any tqdm loop
+        self.log = logging.getLogger('for_tqdm' + str(datetime.now()))
+        self.log.setLevel(logging.root.level)
+        self.log.addHandler(TqdmLoggingHandler())
+        self.log.propagate = False
+
+        # Preparing the dataset
+        # type will be dwi_ml.data.dataset.data_list.DataListForTorch or,
+        # in lazy version, LazyDataListForTorch
+        self.volume_groups = [str]
+        self.streamline_groups = [str]
+        self.nb_features = [int]
+
+        self.is_lazy = lazy
+        self.cache_size = cache_size
+        if self.is_lazy and self.cache_size is None:
+            raise ValueError("For lazy data, the cache size cannot be None. "
+                             "Maybe you meant 0?")
+
+        # Preparing the testing set and validation set
+        # In non-lazy data, the cache_size is not used.
+        self.training_set = MultisubjectSubset(
+            'training', hdf5_filename, self.is_lazy, self.log, cache_size)
+        self.validation_set = MultisubjectSubset(
+            'validation', hdf5_filename, self.is_lazy, self.log, cache_size)
 
     @property
-    def attributes(self):
-        all_params = super().attributes
-        other_params = {
+    def attributes(self) -> Dict[str, Any]:
+        all_params = {
+            'hdf5_path': self.hdf5_path,
+            'name': self.name,
+            'taskman_managed': self.taskman_managed,
+            'volume_groups': self.volume_groups,
+            'nb_features': self.nb_features,
+            'streamline_groups': self.streamline_groups,
+            'is_lazy': self.is_lazy,
             'cache_size': self.cache_size,
         }
-        all_params.update(other_params)
         return all_params
 
-    @staticmethod
-    def _build_data_list(hdf_file):
-        assert hdf_file is not None
-
-        return LazySubjectsDataList(hdf_file)
-
-    @staticmethod
-    def _init_subj_from_hdf(hdf_file, subject_id, volume_groups, nb_features,
-                            streamline_groups, log):
-        return LazySubjectData.init_from_hdf(
-            subject_id, log, hdf_file,
-            (volume_groups, nb_features, streamline_groups))
-
-    def get_subject_data(self, item) -> LazySubjectData:
-        """Contains both MRI data and streamlines. Here, data_list is a
-        LazyDataListForTorch, and its elements are LazySubjectData, which
-        means we need to open a handle to read the hdf5 file and read the data.
+    def load_data(self):
         """
-        if self.hdf_handle is None:
-            self.hdf_handle = h5py.File(self.hdf5_path, 'r')
-        return self.data_list[(item, self.hdf_handle)]
+        Load raw dataset into memory.
+        """
+        with h5py.File(self.hdf5_path, 'r') as hdf_file:
+            # Load main attributes from hdf file, but each process calling
+            # the collate_fn must open its own hdf_file
+            if hdf_file.attrs["version"] < 2:
+                logging.warning("Current dwi_ml version should work with "
+                                "hdf database version >= 2. This could fail."
+                                "database version: {}"
+                                .format(hdf_file.attrs["version"]))
 
-    def get_subject_mri_group_as_tensor(self, subj_idx: int, group_idx: int,
-                                        device: torch.device = None,
-                                        non_blocking: bool = False):
-        """Here, get_subject_data is a LazySubjectData, its mri_data is a
-        List[LazySubjectMRIData], not loaded yet but we will load it now using
-        as_tensor.
-        mri_group_idx corresponds to the group number from the config_file."""
-        if self.cache_size > 0:
-            # Parallel workers each build a local cache
-            # (data is duplicated across workers, but there is no need to
-            # serialize/deserialize everything)
-            if self.volume_cache_manager is None:
-                self.volume_cache_manager = \
-                    SingleThreadCacheManager(self.cache_size)
+            # Basing group names on the first training subject
+            logging.debug("Loading the first training subject's group "
+                          "information. Others should fit")
+            subject_keys = sorted(hdf_file.attrs['training_subjs'])
+            self.volume_groups, self.nb_features, self.streamline_groups = \
+                find_groups_info(hdf_file, subject_keys[0], self.log)
 
-            try:
-                # General case: Data is already cached
-                volume_data = self.volume_cache_manager[subj_idx]
-            except KeyError:
-                # volume_data isn't cached; fetch and cache it
-                # This will open a hdf handle if it not created yet.
-                mri = self.get_subject_data(subj_idx).mri_data_list[group_idx]
-                volume_data = mri.as_tensor
+            # Saving the group info in the subsets too
+            self.training_set.volume_groups = self.volume_groups
+            self.training_set.streamline_groups = self.streamline_groups
+            self.training_set.nb_features = self.nb_features
 
-                # Send volume_data on device and keep it there while it's
-                # cached
-                volume_data = volume_data.to(device=device,
-                                             non_blocking=non_blocking)
+            self.validation_set.volume_groups = self.volume_groups
+            self.validation_set.streamline_groups = self.streamline_groups
+            self.validation_set.nb_features = self.nb_features
 
-                self.volume_cache_manager[subj_idx] = volume_data
-            return volume_data
+            # LOADING
+            self._load_subset(self.training_set, hdf_file)
+            self._load_subset(self.validation_set, hdf_file)
+
+    def _load_subset(self, subset: MultisubjectSubset, hdf_file: h5py.File):
+        logging.info("\n"
+                     "=============\n"
+                     "         Dataset: Loading {} set\n"
+                     "==============".format(subset.set_name))
+        subject_keys = sorted(hdf_file.attrs[subset.set_name + '_subjs'])
+
+        logging.debug('Dataset: hdf_file (subject) keys for the {} set '
+                      'are: {}'.format(subset.set_name, subject_keys))
+
+        # Build empty data_list (lazy or not) and initialize values
+        subset.subjs_list = self._build_empty_data_list()
+        subset.streamline_ids_per_subj = \
+            [defaultdict(slice) for _ in self.streamline_groups]
+        subset.total_streamlines = [0 for _ in self.streamline_groups]
+        streamline_lengths_mm_list = [[] for _ in self.streamline_groups]
+
+        # Using tqdm progress bar, load all subjects from hdf_file
+        for subj_id in tqdm.tqdm(subject_keys, ncols=100,
+                                 disable=self.taskman_managed):
+            # Create subject's container
+            # Uses SubjectData or LazySubjectData based on the class
+            # calling this method.
+            self.log.debug("Dataset: Creating subject '{}':".format(subj_id))
+            subj_data = self._init_subj_from_hdf(
+                hdf_file, subj_id, self.volume_groups, self.nb_features,
+                self.streamline_groups, self.log)
+
+            # Add subject to the list
+            self.log.debug("Dataset: Adding subject to the list.")
+            subj_idx = subset.subjs_list.add_subject(subj_data)
+
+            if subj_data.is_lazy:
+                self.log.debug("Dataset: Temporarily adding hdf handle to "
+                               "subj to arrange streamlines.")
+                subj_data = subset.subjs_list[(subj_idx, hdf_file)]
+                self.log.debug("--> Handle: {}".format(subj_data.hdf_handle))
+
+            # Arrange streamlines
+            # In the lazy case, we need to load the data first using the
+            # __getitem__ from the datalist, and passing the hdf handle.
+            # For the non-lazy version, this does nothing.
+            subj_data.add_handle(hdf_file)
+            for i in range(len(self.streamline_groups)):
+                streamline_lengths_mm_list[i] = self._arrange_streamlines(
+                    subset, subj_data, subj_idx, streamline_lengths_mm_list[i],
+                    i)
+
+        # Arrange final data properties
+        subset.streamline_lengths_mm = \
+            [np.concatenate(streamline_lengths_mm_list[i], axis=0)
+             for i in range(len(self.streamline_groups))]
+
+        # No need to return 'subset': instance attributes are modified
+        # in-place.
+
+    def _arrange_streamlines(
+            self, subset: MultisubjectSubset,
+            subj_data: Union[SubjectData, LazySubjectData], subj_idx: int,
+            group_streamline_lengths_mm_list: List, group_idx: int):
+        """
+        Concatenating streamlines but remembering which id was which subject's
+        streamline.
+
+        The subj_data.streamlines depend on the class: np.Array in the non-lazy
+        version, or property in the lazy version, returning streamlines only if
+        a handle is present.
+        """
+        group = self.streamline_groups[group_idx]
+
+        self.log.debug("     => Arranging streamlines per ID for group '{}'."
+                       .format(group))
+
+        if subj_data.is_lazy and subj_data.hdf_handle is None:
+            self.log.warning("*    Dataset: Subject's handle must be present! "
+                             "Will bug!")
+
+        # Assign a unique ID to every streamline
+        n_streamlines = len(subj_data.sft_data_list[group_idx].streamlines)
+        self.log.debug("*    Dataset: Subject had {} streamlines for this "
+                       "group.".format(n_streamlines))
+
+        # Assigning these id in the dict for this group
+        start = subset.total_streamlines[group_idx]
+        end = subset.total_streamlines[group_idx] + n_streamlines
+        subset.streamline_ids_per_subj[group_idx][subj_idx] = slice(start, end)
+
+        # Update total nb of streamlines in the dataset for this group
+        subset.total_streamlines[group_idx] += n_streamlines
+
+        # Get number of timesteps per streamline for this group
+        group_streamline_lengths_mm_list.append(
+            np.array(subj_data.sft_data_list[group_idx].streamlines.lengths_mm,
+                     dtype=np.int16))
+
+        return group_streamline_lengths_mm_list
+
+    def _build_empty_data_list(self):
+        if self.is_lazy:
+            return LazySubjectsDataList(self.hdf5_path, self.log)
         else:
-            # No cache is used
-            mri = self.get_subject_data(subj_idx).mri_data_list[group_idx]
-            volume_data = mri.as_tensor
-            volume_data.to(device=device, non_blocking=non_blocking)
-            return volume_data
+            return SubjectsDataList(self.hdf5_path, self.log)
 
-    def __del__(self):
-        if self.hdf_handle is not None:
-            self.hdf_handle.close()
-
-
-def init_dataset(lazy: bool, hdf5_filename: str, subjs_set: str,
-                 name: str = None, taskman_managed: bool = None,
-                 cache_size: int = None, **_):
-    if lazy:
-        dataset = LazyMultiSubjectDataset(hdf5_filename, subjs_set, name,
-                                          taskman_managed, cache_size)
-    else:
-        dataset = MultiSubjectDataset(hdf5_filename, subjs_set, name,
-                                      taskman_managed)
-
-    dataset.load_data()
-
-    return dataset
+    def _init_subj_from_hdf(self, hdf_file, subject_id, volume_groups,
+                            nb_features, streamline_groups, log):
+        if self.is_lazy:
+            return LazySubjectData.init_from_hdf(
+                subject_id, log, hdf_file,
+                (volume_groups, nb_features, streamline_groups))
+        else:
+            return SubjectData.init_from_hdf(
+                subject_id, log, hdf_file,
+                (volume_groups, nb_features, streamline_groups))

--- a/dwi_ml/data/dataset/utils.py
+++ b/dwi_ml/data/dataset/utils.py
@@ -27,7 +27,7 @@ def find_groups_info(hdf_file, subj_id: str, log):
 
     log.info("Volume groups are: {}".format(volume_groups))
     log.info("Number of features in each of these groups: {}"
-                  .format(nb_features))
+             .format(nb_features))
     log.info("Streamline groups are: {}".format(streamline_groups))
 
     return volume_groups, nb_features, streamline_groups

--- a/dwi_ml/experiment/monitoring.py
+++ b/dwi_ml/experiment/monitoring.py
@@ -29,11 +29,11 @@ class ValueHistoryMonitor(object):
         self.current_epoch_history = []  # The list of values in current epoch
 
     @property
-    def num_updates(self):
+    def nb_updates(self):
         return len(self.all_updates_history)
 
     @property
-    def num_epochs(self):
+    def nb_epochs(self):
         return len(self.epochs_means_history)
 
     def update(self, value):

--- a/dwi_ml/training/checks_for_experiment_parameters.py
+++ b/dwi_ml/training/checks_for_experiment_parameters.py
@@ -132,14 +132,14 @@ def check_neighborhood(sphere_radius: float, grid_radius: int):
         return None, None
 
 
-def check_previous_dir(num_previous_dirs: int):
-    check_similar_to_none(num_previous_dirs, 'num_previous_dirs')
-    check_int_instance(num_previous_dirs, 'num_previous_dirs')
+def check_previous_dir(nb_previous_dirs: int):
+    check_similar_to_none(nb_previous_dirs, 'nb_previous_dirs')
+    check_int_instance(nb_previous_dirs, 'nb_previous_dirs')
 
-    if num_previous_dirs is None:
-        num_previous_dirs = 0
+    if nb_previous_dirs is None:
+        nb_previous_dirs = 0
 
-    return num_previous_dirs
+    return nb_previous_dirs
 
 
 def check_max_epochs(max_epochs: int):
@@ -215,11 +215,11 @@ def check_avoid_cpu_computations(avoid_cpu_computations: bool):
     return avoid_cpu_computations
 
 
-def check_num_cpu_workers(num_workers: int):
-    check_similar_to_none(num_workers, 'num_workers')
-    check_int_instance(num_workers, 'num_workers')
+def check_nb_cpu_workers(nb_workers: int):
+    check_similar_to_none(nb_workers, 'nb_workers')
+    check_int_instance(nb_workers, 'nb_workers')
 
-    return num_workers
+    return nb_workers
 
 
 def check_worker_interpolation(worker_interpolation: bool):
@@ -271,8 +271,8 @@ def check_all_experiment_parameters(conf: dict):
         conf['input']['neighborhood']['grid_radius'])
     all_params['neighborhood_type'] = n_type
     all_params['neighborhood_radius'] = n_radius
-    all_params['num_previous_dirs'] = check_previous_dir(
-        conf['input']['num_previous_dirs'])
+    all_params['nb_previous_dirs'] = check_previous_dir(
+        conf['input']['nb_previous_dirs'])
 
     # Epochs:
     all_params['max_epochs'] = check_max_epochs(
@@ -295,8 +295,8 @@ def check_all_experiment_parameters(conf: dict):
         conf['memory']['cache_manager'], lazy)
     all_params['avoid_cpu_computations'] = check_avoid_cpu_computations(
         conf['memory']['avoid_cpu_computations'])
-    all_params['num_cpu_workers'] = check_num_cpu_workers(
-        conf['memory']['num_cpu_workers'])
+    all_params['nb_cpu_workers'] = check_nb_cpu_workers(
+        conf['memory']['nb_cpu_workers'])
     all_params['worker_interpolation'] = check_worker_interpolation(
         conf['memory']['worker_interpolation'])
     all_params['taskman_managed'] = check_taskman_managed(

--- a/please_copy_and_adapt/training_parameters.yaml
+++ b/please_copy_and_adapt/training_parameters.yaml
@@ -69,10 +69,10 @@ input:
     #     radius 1, that's 27 points. With radius 2, that's 125 points.
     #     * Can't be used together with sphere_radius.
     grid_radius: null
-  # num_previous_dirs: int
+  # nb_previous_dirs: int
   #     Concatenate X previous streamline directions to the input vector. Null
   #     is equivalent to 0.
-  num_previous_dirs: 0
+  nb_previous_dirs: 0
 
 model:
   # Add your model's parameters
@@ -121,11 +121,11 @@ memory:
   #     skipped in the batch sampler. Ex: interpolation, directions
   #     computations from the streamlines coordinates, etc.
   avoid_cpu_computations: True
-  # num_cpu_workers: int
+  # nb_cpu_workers: int
   #     Number of parallel CPU workers.
-  num_cpu_workers: 0
+  nb_cpu_workers: 0
   # worker_interpolation: bool
-  #     If set, if using num_cpu_workers > 0, interpolation will be done on CPU
+  #     If set, if using nb_cpu_workers > 0, interpolation will be done on CPU
   #     by the workers instead of on the main thread using the chosen device.
   worker_interpolation: False
   # taskman_managed: bool

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ contextlib2
 future==0.17.1
 numpy==1.18.*
 scipy==1.4.*
+# h5py must absolutely be >2.4: that's when it became thread-safe
 h5py==2.10.*
 dipy==1.3.*
 

--- a/tests/test_batch_sampler_iter.py
+++ b/tests/test_batch_sampler_iter.py
@@ -6,8 +6,7 @@ from os import path
 
 from torch.utils.data.dataloader import DataLoader
 
-from dwi_ml.data.dataset.multi_subject_containers import (
-    LazyMultiSubjectDataset, MultiSubjectDataset)
+from dwi_ml.data.dataset.multi_subject_containers import MultiSubjectDataset
 from dwi_ml.model.batch_samplers import (BatchStreamlinesSampler1IPV)
 
 
@@ -28,8 +27,10 @@ def parse_args():
 def test_sampler(fake_dataset, batch_size, step_size):
     # Initialize batch sampler
     print('Initializing sampler...')
+    training_set = fake_dataset.training_set
+
     batch_sampler = BatchStreamlinesSampler1IPV(
-        fake_dataset, 'streamlines', 'input', batch_size, 1234,
+        training_set, 'streamlines', 'input', batch_size, 1234,
         step_size=step_size)
 
     # Use it in the dataloader
@@ -37,7 +38,7 @@ def test_sampler(fake_dataset, batch_size, step_size):
     # supposed to work with dict too.
     # See https://github.com/PyTorchLightning/pytorch-lightning/issues/1918
     print('Initializing DataLoader')
-    dataloader = DataLoader(fake_dataset, batch_sampler=batch_sampler,
+    dataloader = DataLoader(training_set, batch_sampler=batch_sampler,
                             collate_fn=batch_sampler.load_batch)
     print(dataloader)
 
@@ -62,7 +63,7 @@ def test_non_lazy():
 
     # Initialize dataset
     print('Initializing dataset...')
-    fake_dataset = MultiSubjectDataset(args.hdf5_filename, 'training_subjs')
+    fake_dataset = MultiSubjectDataset(args.hdf5_filename, lazy=False)
     fake_dataset.load_data()
 
     print('\n=============================Test with batch size 1000')
@@ -80,8 +81,7 @@ def test_lazy():
 
     # Initialize dataset
     print('Initializing dataset...')
-    fake_dataset = LazyMultiSubjectDataset(args.hdf5_filename,
-                                           'training_subjs')
+    fake_dataset = MultiSubjectDataset(args.hdf5_filename, lazy=True)
     fake_dataset.load_data()
 
     print('\n=============================Test with batch size 1000')

--- a/tests/test_batch_sampler_load_batch.py
+++ b/tests/test_batch_sampler_load_batch.py
@@ -11,8 +11,7 @@ from dipy.io.stateful_tractogram import (StatefulTractogram,
                                          set_sft_logger_level)
 from dipy.io.streamline import (save_tractogram, Space)
 
-from dwi_ml.data.dataset.multi_subject_containers import (
-    LazyMultiSubjectDataset, MultiSubjectDataset)
+from dwi_ml.data.dataset.multi_subject_containers import MultiSubjectDataset
 from dwi_ml.model.batch_samplers import (BatchStreamlinesSampler1IPV)
 
 
@@ -43,11 +42,13 @@ def test_batch_loading_no_computations(
     now = datetime.now().time()
     logging.root.setLevel('DEBUG')
 
+    training_set = fake_dataset.training_set
+
     # Initialize batch sampler
     print('Initializing sampler...')
     rng_seed = now.minute * 100 + now.second
     batch_sampler = BatchStreamlinesSampler1IPV(
-        fake_dataset, 'streamlines', 'input', batch_size, rng_seed,
+        training_set, 'streamlines', 'input', batch_size, rng_seed,
         step_size=step_size, avoid_cpu_computations=True,
         split_streamlines_ratio=split_ratio,
         noise_gaussian_size=noise_size,
@@ -84,16 +85,18 @@ def test_batch_loading_computations(fake_dataset, batch_size, step_size,
     logging.root.setLevel('DEBUG')
     now = datetime.now().time()
 
+    training_set = fake_dataset.training_set
+
     # Initialize batch sampler
     print('Initializing sampler...')
     rng_seed = now.minute * 100 + now.second
 
     batch_sampler = BatchStreamlinesSampler1IPV(
-        fake_dataset, 'streamlines', 'input', batch_size, rng_seed,
+        training_set, 'streamlines', 'input', batch_size, rng_seed,
         step_size=step_size, avoid_cpu_computations=False,
         neighborhood_type=neighborhood_type,
         neighborhood_radius_vox=neighborhood_radius,
-        num_previous_dirs=2)
+        nb_previous_dirs=2)
 
     batch_generator = batch_sampler.__iter__()
 
@@ -145,7 +148,7 @@ def test_non_lazy(ref, affine, header, saving_path):
     # Initialize dataset
     print('Initializing dataset...')
     logging.root.setLevel('INFO')
-    fake_dataset = MultiSubjectDataset(args.hdf5_filename, 'training_subjs')
+    fake_dataset = MultiSubjectDataset(args.hdf5_filename, lazy=False)
     fake_dataset.load_data()
 
     print('\n\n\n=======================Test with batch size 10000 + resample '
@@ -174,8 +177,7 @@ def test_lazy(ref, affine, header, saving_path):
     # Initialize dataset
     print('Initializing dataset...')
     logging.root.setLevel('INFO')
-    fake_dataset = LazyMultiSubjectDataset(args.hdf5_filename,
-                                           'training_subjs')
+    fake_dataset = MultiSubjectDataset(args.hdf5_filename, lazy=True)
     fake_dataset.load_data()
 
     print('\n\n\n=======================Test with batch size 10000 + resample')


### PR DESCRIPTION
## Description

There was a redondancy in the code when creating the dataset:

```
training_set = create_dataset(**params)
validation_set = create_dataset(**params)
```

meaning that the two datasets could have different parameters (ex, nb of features), which does not really makes sense in machine learning. So now they have been merged together in the multisubjectDataset, which will load data both for the training and validation set.

The batch samplers, however, are kept separated. We could indeed suppose that a user could want a different amount of noise addition during training and validation, for instance.

Doing this forced to change the hdf_handle management. But as of h5py2.4, the hdf5 file is now considered thread-safe so management could be alleged in dwi_ml.

## Testing data and script
All tests have been re-ran.

