### PR TITLE
Fixes from running on tractoinferno

### DIFF
--- a/dwi_ml/data/hdf5_creation.py
+++ b/dwi_ml/data/hdf5_creation.py
@@ -136,12 +136,14 @@ def process_volumes(group: str, file_list: List[str], subj_id,
 
         data, affine, res, _ = _load_volume_to4d(data_file)
 
-        if not np.array_equal(affine, group_affine):
+        if not np.allclose(affine, group_affine):
             raise ValueError('Data file {} does not have the same affine as '
                              'other files in group {}. Data from each group '
                              'will be concatenated, and should have the same '
-                             'affine and voxel resolution.'
-                             .format(data_name, group))
+                             'affine and voxel resolution.\n'
+                             'Affine: {}\n'
+                             'Group affine: {}'
+                             .format(data_name, group, affine, group_affine))
 
         if not np.array_equal(res, group_res):
             raise ValueError('Data file {} does not have the same resolution '

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,11 @@ nibabel>=3.0.0
 PyYAML==5.4
 comet-ml>=3.0.2
 contextlib2
+nested_lookup
 
 ## Necessary but should be installed with scilpy (Last check: 01/2020, version 1.1.0):
 future==0.17.1
-numpy==1.18.*
+numpy>=1.18.*
 scipy==1.4.*
 # h5py must absolutely be >2.4: that's when it became thread-safe
 h5py==2.10.*


### PR DESCRIPTION
- Fixed requirements
- Changed affine checks from array_equal to allclose because in one case for tractoinferno, affines were not equal due to numerical imprecision.