### PR TITLE
Allow numerical imprecisions in the resolution

### DIFF
--- a/dwi_ml/data/hdf5_creation.py
+++ b/dwi_ml/data/hdf5_creation.py
@@ -145,12 +145,14 @@ def process_volumes(group: str, file_list: List[str], subj_id,
                              'Group affine: {}'
                              .format(data_name, group, affine, group_affine))
 
-        if not np.array_equal(res, group_res):
+        if not np.allclose(res, group_res):
             raise ValueError('Data file {} does not have the same resolution '
                              'as other files in group {}. Data from each '
                              'group will be concatenated, and should have the '
-                             'same affine and voxel resolution.'
-                             .format(data_name, group))
+                             'same affine and voxel resolution.\n'
+                             'Resolution: {}\n'
+                             'Group resolution: {}'
+                             .format(data_name, group, res, group_res))
 
         try:
             group_data = np.append(group_data, data, axis=-1)


### PR DESCRIPTION
Changed np.array_equal to np.allclose when verifying that files have the same resolution.