### PR TITLE
Adding masks to hdf5

### DIFF
--- a/doc/config_file.rst
+++ b/doc/config_file.rst
@@ -1,3 +1,5 @@
+.. _ref_config_file:
+
 3. Preparing the config file
 ============================
 
@@ -9,6 +11,7 @@ To create the hdf5 file, you will need a config file such as below.
         "group1": {
             "type": "volume",
             "files": ["dwi/dwi_tractoflow.nii.gz", "anat/t1_tractoflow.nii.gz"]
+            "standardization": "all"
              },
         "group2": {
             "type": "streamlines",
@@ -16,13 +19,32 @@ To create the hdf5 file, you will need a config file such as below.
              }
     }
 
-- The group names could be 'input_volume', 'target_volume', 'target_directions', or anything. Make sure your training scripts and your model's batch_sampler use the same keys.
-- The groups 'files' must exist in every subject folder inside dwi_ml_ready.
+- The group **names** could be 'input_volume', 'target_volume', 'target_directions', or anything. Make sure your training scripts and your model's batch_sampler use the same keys.
+
+- The groups **"files"** must exist in every subject folder inside dwi_ml_ready.
 
     - There is the possibility to add a wildcard (*) that will be replaced by the subject's id while loading. Ex: anat/\*__t1.nii.gz would become anat/subjX__t1.nii.gz.
     - For streamlines, there is the possibility to use 'ALL' to load all bundles present. Ex: "files": ["good_bundles/ALL", "bad_bundles/ALL"]
     - The files from each group will be concatenated in the hdf5 (either as a final volume or as a final tractogram).
-- The groups 'type' must be recognized in dwi_ml. Currently, accepted datatype are:
+
+- The groups **"type"** must be recognized in dwi_ml. Currently, accepted datatype are:
 
     - 'volume': for instance, a dwi, an anat, mask, t1, fa, etc.
     - 'streamlines': for instance, a .trk, .tck file (anything accepted by Dipy's Stateful Tractogram).
+
+- The groups **"standardization"** must be of of
+
+    - "all", to apply standardization (normalization) to the final (concatenated) file
+    - "independent", to apply it independently on the last dimension of the data (ex, for a fODF, it would apply it independently on each SH).
+    - "per_file", to apply it independently on each file included in the group.
+    - "none", to skip this step (ex: for binary masks, which must stay binary).
+
+    ****A note about data standardization**
+
+    Data is standardized (normalized) during data creation: data = (data - mean) / std.
+
+    If all voxel were to be used, most of them would probably contain the background of the data, bringing the mean and std probably very close to 0. Thus, non-zero voxels only are used to compute the mean and std, or voxels inside the provided mask if any.
+
+    In the latest case, voxels outside the mask could have been set to NaN, but a test with the b0 as a mask showed that some streamlines had points outside the mask (probably due to data interpolation or to the skull-stripping technique of the b0 mask). The safer choice, chosen in dwi_ml, was to simply modify all voxels [ data = (data - mean) / std ], even voxels outside the mask.
+
+    Mask is provided using --std_mask in the script create_hdf5_dataset.py.

--- a/doc/creating_hdf5.rst
+++ b/doc/creating_hdf5.rst
@@ -8,7 +8,7 @@ The possibility of laziness
 
 We chose to base our code on the hdf5 data. One reason is that it allows to regroup your data in an organized way to ensure that all you data is present. But the main reason for using hdf5 is that it is then possible to load only some chosen streamlines for each batch in the training set instead of having to keep all the streamlines in memory, which can be very heavy. This way of handling the data is called "lazy" in our project.
 
-You will use the **create_hdf5_dataset.py** script to create a hdf5 file. You need to prepare config files to use this script (see lower).
+You will use the **create_hdf5_dataset.py** script to create a hdf5 file. You need to prepare config files to use this script (see :ref:`ref_config_file`).
 
 Creating the hdf5
 *****************
@@ -40,11 +40,3 @@ Here is the output format created by create_hdf5_dataset.py and recognized by th
     hdf5['subj1']['group1']['offsets']
     hdf5['subj1']['group1']['lengths']
     hdf5['subj1']['group1']['euclidean_lengths']
-
-**A note about data standardization**
-
-Data is standardized (normalized) during data creation: data = (data - mean) / std. (Each features/modalities independently or not).
-
-If all voxel were to be used, most of them would probably contain the background of the data, bringing the mean and std probably very close to 0. Thus, non-zero voxels only are used to compute the mean and std, or voxels inside the provided mask if any.
-
-In the latest case, voxels outside the mask could have been set to NaN, but a test with the b0 as a mask showed that some streamlines had points outside the mask (probably due to data interpolation or to the skull-stripping technique of the b0 mask). The safer choice, chosen in dwi_ml, was to simply modify all voxels to data = (data - mean) / std, even voxels outside the mask.

--- a/dwi_ml/data/hdf5_creation.py
+++ b/dwi_ml/data/hdf5_creation.py
@@ -121,6 +121,11 @@ def process_volumes(group: str, file_list: List[str], subj_id,
     group_data, group_affine, group_res, group_header = \
         _load_volume_to4d(first_file)
 
+    if standardization == 'per_file':
+        logging.debug('      *Standardizing sub-data')
+        group_data = standardize_data(group_data, subj_std_mask_data,
+                                      independent=False)
+
     # Other files must fit (data shape, affine, voxel size)
     # It is not a promise that data has been correctly registered, but it
     # is a minimal check.
@@ -163,8 +168,8 @@ def process_volumes(group: str, file_list: List[str], subj_id,
 
         if standardization == 'per_file':
             logging.debug('      *Standardizing sub-data')
-            group_data = standardize_data(group_data, subj_std_mask_data,
-                                          independent=False)
+            data = standardize_data(data, subj_std_mask_data,
+                                    independent=False)
 
         try:
             group_data = np.append(group_data, data, axis=-1)

--- a/dwi_ml/data/processing/dwi/dwi.py
+++ b/dwi_ml/data/processing/dwi/dwi.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import logging
+
 from dipy.core.gradients import GradientTable
 from dipy.core.sphere import Sphere
 from dipy.data import get_sphere
@@ -7,6 +9,8 @@ import nibabel as nib
 import numpy as np
 from scilpy.io.utils import validate_sh_basis_choice
 from scilpy.reconst.raw_signal import compute_sh_coefficients
+
+eps = 1e-6
 
 
 def standardize_data(data: np.ndarray, mask: np.ndarray = None,
@@ -54,12 +58,15 @@ def standardize_data(data: np.ndarray, mask: np.ndarray = None,
     if independent:
         mean = np.mean(data[mask], axis=0)
         std = np.std(data[mask], axis=0)
-        std[std == 0] = 1
     else:
         mean = np.mean(data[mask])
         std = np.std(data[mask])
-        if std == 0:
-            std = 1
+
+    # If std ~ 0, replace by eps.
+    std = np.maximum(std, eps)
+
+    logging.debug("          => Mean and std were: {:.2f} and {:.2f}"
+                  .format(mean, std))
 
     standardized_data = (data - mean) / std
     # standardized_data[~mask] = np.nan

--- a/please_copy_and_adapt/config_file_example.json
+++ b/please_copy_and_adapt/config_file_example.json
@@ -2,8 +2,15 @@
 {
     "input": {
         "type": "volume",
-       	"files": ["dwi/dwi_tractoflow.nii.gz", "anat/t1_tractoflow.nii.gz"]
+       	"files": ["dwi/dwi_tractoflow.nii.gz", "anat/t1_tractoflow.nii.gz"],
+        "standardization": "all"
 	     },
+
+    "tracking_mask": {
+      "type": "volume",
+      "files": ["mask/mask_wm.nii.gz"],
+      "standardization": "None"
+    },
 
     "streamlines": {
         "type": "streamlines",


### PR DESCRIPTION
- Allowing more than one mask: ex: we often have gm and wm masks. If we don't want to combine them in our dwi_ml folder, we can merge them directly in the hdf5.
- Standardization option now in the config file, so we can choose differently for each volume group. Ex: we can have a group in the hdf5 for masks, useful at tracking time (that we don't want to standardize)