### PR TITLE
Adding back defaults

### DIFF
--- a/dwi_ml/data/dataset/utils.py
+++ b/dwi_ml/data/dataset/utils.py
@@ -4,7 +4,6 @@ import logging
 
 from dwi_ml.data.dataset.multi_subject_containers import MultiSubjectDataset
 from dwi_ml.experiment_utils.timer import Timer
-from dwi_ml.experiment_utils.prints import format_dict_to_str
 
 
 def add_args_dataset(p: argparse.ArgumentParser):
@@ -40,7 +39,7 @@ def prepare_multisubjectdataset(args, load_training=True, load_validation=True,
                newline=True, color='blue'):
         dataset = MultiSubjectDataset(
             args.hdf5_file, taskman_managed=args.taskman_managed,
-            lazy=args.lazy, cache_size=args.cache_size)
+            lazy=args.lazy, subset_cache_size=args.cache_size)
         dataset.load_data(load_training, load_validation, load_testing)
 
         logging.info("Number of subjects loaded: \n"

--- a/dwi_ml/data/processing/volume/interpolation.py
+++ b/dwi_ml/data/processing/volume/interpolation.py
@@ -141,7 +141,7 @@ def interpolate_volume_in_neighborhood(
         are interpolated (i.e. neighborhood = (0,0,0) ).
     device: torch device.
     """
-    if neighborhood_points is not None:
+    if neighborhood_points is not None and len(neighborhood_points) > 0:
         n_input_points = coords.shape[0]
 
         # Extend the coords array with the neighborhood coordinates

--- a/dwi_ml/models/main_models.py
+++ b/dwi_ml/models/main_models.py
@@ -21,8 +21,8 @@ class MainModelAbstract(torch.nn.Module):
 
     It should also define a forward() method.
     """
-    def __init__(self, experiment_name, normalize_directions=True,
-                 neighborhood_type=None, neighborhood_radius=None):
+    def __init__(self, experiment_name: str, normalize_directions: bool = True,
+                 neighborhood_type: str = None, neighborhood_radius=None):
         """
         Params
         ------
@@ -33,11 +33,13 @@ class MainModelAbstract(torch.nn.Module):
             size is fixed, it shouldn't make any difference. If streamlines are
             compressed, in theory you should normalize, but you could hope that
             not normalizing could give back to the algorithm a sense of
-            distance between points.
-        neighborhood_type: Union[str, None]
+            distance between points. Default: True.
+        neighborhood_type: str
             For usage explanation, see prepare_neighborhood_information.
-        neighborhood_radius: Union[int, float, Iterable[float], None]
+            Default: None.
+        neighborhood_radius: Union[int, float, Iterable[float]]
             For usage explanation, see prepare_neighborhood_information.
+            Default: None.
         """
         super().__init__()
 
@@ -183,13 +185,13 @@ class MainModelAbstract(torch.nn.Module):
 
 
 class MainModelWithPD(MainModelAbstract):
-    def __init__(self, experiment_name, nb_previous_dirs,
-                 normalize_directions=False,
-                 neighborhood_type=None, neighborhood_radius=None):
+    def __init__(self, experiment_name: str, nb_previous_dirs: int = 0,
+                 normalize_directions: bool = True,
+                 neighborhood_type: str = None, neighborhood_radius=None):
         """
         nb_previous_dirs: int
             Number of previous direction (i.e. [x,y,z] information) to be
-            received.
+            received. Default: 0.
         """
         super().__init__(experiment_name, normalize_directions,
                          neighborhood_type, neighborhood_radius)

--- a/dwi_ml/training/batch_samplers.py
+++ b/dwi_ml/training/batch_samplers.py
@@ -40,8 +40,9 @@ from dwi_ml.data.dataset.multi_subject_containers import MultisubjectSubset
 class DWIMLBatchSampler(Sampler):
     def __init__(self, dataset: MultisubjectSubset,
                  streamline_group_name: str, batch_size: int,
-                 batch_size_units: str, nb_streamlines_per_chunk: int,
-                 rng: int, nb_subjects_per_batch: int, cycles: int):
+                 batch_size_units: str, nb_streamlines_per_chunk: int = 256,
+                 rng: int = None, nb_subjects_per_batch: int = None,
+                 cycles: int = None):
         """
         Parameters
         ----------
@@ -60,17 +61,18 @@ class DWIMLBatchSampler(Sampler):
             In the case of a batch size in terms of 'length_mm', chunks of n
             streamlines are sampled at once, and then their size is checked,
             either removing streamlines if exceeded, or else sampling a new
-            chunk of ids.
+            chunk of ids. Default = 256, for no good reason.
         rng : int
-            Seed for the random number generator.
+            Seed for the random number generator. Default = None.
         nb_subjects_per_batch : int
             Maximum number of subjects to be used in a single batch. Depending
             on the model, this can avoid loading too many input volumes at the
-            same time, for example. If None, always sample from all subjects.
+            same time, for example. Default: None (always sample from all
+            subjects).
         cycles : int
             Used if `nb_subjects_per_batch` is given. Number of batches
             re-using the same subjects (and thus the same volumes) before
-            sampling new ones.
+            sampling new ones. Default: None.
         """
         super().__init__(dataset)  # This does nothing but python likes it.
 

--- a/dwi_ml/training/trainers.py
+++ b/dwi_ml/training/trainers.py
@@ -40,32 +40,21 @@ class DWIMLAbstractTrainer:
     saved locally in the experiment_path.
     """
     def __init__(self,
-                 batch_sampler_training: DWIMLBatchSampler,
-                 batch_sampler_validation: DWIMLBatchSampler,
-                 batch_loader_training: AbstractBatchLoader,
-                 batch_loader_validation: AbstractBatchLoader,
                  model: MainModelAbstract, experiment_path: str,
-                 experiment_name: str, learning_rate: float,
-                 weight_decay: float, max_epochs: int,
-                 max_batches_per_epoch: int, patience: int,
-                 nb_cpu_processes: int, taskman_managed: bool, use_gpu: bool,
-                 comet_workspace: str, comet_project: str,
-                 from_checkpoint: bool):
+                 experiment_name: str,
+                 batch_sampler_training: DWIMLBatchSampler,
+                 batch_loader_training: AbstractBatchLoader,
+                 batch_sampler_validation: DWIMLBatchSampler = None,
+                 batch_loader_validation: AbstractBatchLoader = None,
+                 learning_rate: float = 0.001,
+                 weight_decay: float = 0.01, max_epochs: int = 10,
+                 max_batches_per_epoch: int = 1000, patience: int = None,
+                 nb_cpu_processes: int = 0, taskman_managed: bool = False,
+                 use_gpu: bool = False, comet_workspace: str = None,
+                 comet_project: str = None, from_checkpoint: bool = False):
         """
         Parameters
         ----------
-        batch_sampler_training: DWIMLBatchSampler
-            Instantiated class used for sampling batches of training data.
-            Data in batch_sampler_training.source_data must be already loaded.
-        batch_sampler_validation: DWIMLBatchSampler
-            Instantiated class used for sampling batches of validation
-            data. Data in batch_sampler_training.source_data must be already
-            loaded. Can be set to None if no validation is used. Then, best
-            model is based on training loss.
-        batch_loader_training: AbstractBatchLoader
-            Instantiated class with a load_batch method able to load data
-            associated to sampled batch ids.
-        batch_loader_validation: idem
         model: MainModelAbstract
             Instatiated class containing your model.
         experiment_path: str
@@ -74,33 +63,51 @@ class DWIMLAbstractTrainer:
         experiment_name: str
             Name of this experiment. This will also be the name that will
             appear online for comet.ml experiment.
+        batch_sampler_training: DWIMLBatchSampler
+            Instantiated class used for sampling batches of training data.
+            Data in batch_sampler_training.source_data must be already loaded.
+        batch_loader_training: AbstractBatchLoader
+            Instantiated class with a load_batch method able to load data
+            associated to sampled batch ids.
+        batch_sampler_validation: DWIMLBatchSampler
+            Similar as before, for the validation set. Can be set to None if no
+            validation is used. Then, best model is based on training loss.
+        batch_loader_validation: AbstractBatchLoader
+            Again, similar as before but can be set to None.
         learning_rate: float
-            Learning rate. Suggestion: 0.001 (torch's default)
+            Learning rate. Default: 0.001 (torch's default)
         weight_decay: float
-            Add a weight decay penalty on the parameters. Suggestion: 0.01.
+            Add a weight decay penalty on the parameters. Default: 0.01.
             (torch's default).
         max_epochs: int
-            Maximum number of epochs. Note that we supervise this maximum to
-            make sure it is not too big for general usage. Epochs lengths will
-            be capped at max_batches_per_epoch.
+            Maximum number of epochs. Default = 10, for no good reason.
         max_batches_per_epoch: int
-            Maximum number of batches per epoch. Exemple: 10000.
+            Maximum number of batches per epoch. Default = 10000, for no good
+            reason.
         patience: int
-            If not None, use early stopping. Defines the number of epochs after
-            which the model should stop if the loss hasn't improved.
+            Use early stopping. Defines the number of epochs after which the
+            model should stop if the loss hasn't improved. Default: None (i.e.
+            no early stopping).
         nb_cpu_processes: int
             Number of parallel CPU workers. Use 0 to avoid parallel threads.
+            Default : 0.
         taskman_managed: bool
             If True, taskman manages the experiment. Do not output progress
             bars and instead output special messages for taskman.
+            Default: False (i.e. use tqdm).
         use_gpu: bool
             If true, use GPU device when possible instead of CPU.
+            Default = False
         comet_workspace: str
-            Your comet workspace. If None, comet.ml will not be used. See our
-            docs/Getting Started for more information on comet and its API key.
+            Your comet workspace. See our docs/Getting Started for more
+            information on comet and its API key. Default= None (comet.ml will
+            not be used).
         comet_project: str
-             Send your experiment to a specific comet.ml project. If None, it
-             will be sent to Uncategorized Experiments.
+             Send your experiment to a specific comet.ml project. Default: None
+             (it will be sent to Uncategorized Experiments).
+        from_checkpoint: bool
+             If true, we do not create the output dir, as it should already
+             exist. Default: False.
         """
         # To developers: do not forget that changes here must be reflected
         # in the save_checkpoint method!
@@ -955,20 +962,21 @@ class DWIMLAbstractTrainer:
 
 class DWIMLTrainerOneInput(DWIMLAbstractTrainer):
     def __init__(self,
-                 batch_sampler_training: DWIMLBatchSampler,
-                 batch_sampler_validation: DWIMLBatchSampler,
-                 batch_loader_training: BatchLoaderOneInput,
-                 batch_loader_validation: BatchLoaderOneInput,
                  model: MainModelAbstract, experiment_path: str,
-                 experiment_name: str, learning_rate: float,
-                 weight_decay: float, max_epochs: int,
-                 max_batches_per_epoch: int, patience: int,
-                 nb_cpu_processes: int, taskman_managed: bool, use_gpu: bool,
-                 comet_workspace: str, comet_project: str,
-                 from_checkpoint: bool):
-        super().__init__(batch_sampler_training, batch_sampler_validation,
-                         batch_loader_training, batch_loader_validation,
-                         model, experiment_path, experiment_name,
+                 experiment_name: str,
+                 batch_sampler_training: DWIMLBatchSampler,
+                 batch_loader_training: AbstractBatchLoader,
+                 batch_sampler_validation: DWIMLBatchSampler = None,
+                 batch_loader_validation: AbstractBatchLoader = None,
+                 learning_rate: float = 0.001,
+                 weight_decay: float = 0.01, max_epochs: int = 10,
+                 max_batches_per_epoch: int = 1000, patience: int = None,
+                 nb_cpu_processes: int = 0, taskman_managed: bool = False,
+                 use_gpu: bool = False, comet_workspace: str = None,
+                 comet_project: str = None, from_checkpoint: bool = False):
+        super().__init__(model, experiment_path, experiment_name,
+                         batch_sampler_training, batch_loader_training,
+                         batch_sampler_validation, batch_loader_validation,
                          learning_rate, weight_decay, max_epochs,
                          max_batches_per_epoch, patience,
                          nb_cpu_processes, taskman_managed, use_gpu,

--- a/dwi_ml/training/utils/trainer.py
+++ b/dwi_ml/training/utils/trainer.py
@@ -51,9 +51,9 @@ def prepare_trainer(training_batch_sampler, validation_batch_sampler,
     # Instantiate trainer
     with Timer("\n\nPreparing trainer", newline=True, color='red'):
         trainer = DWIMLAbstractTrainer(
-            training_batch_sampler, validation_batch_sampler,
-            training_batch_loader, validation_batch_loader, model,
-            args.experiment_path, args.experiment_name,
+            model, args.experiment_path, args.experiment_name,
+            training_batch_sampler, training_batch_loader,
+            validation_batch_sampler, validation_batch_loader,
             # COMET
             comet_project=args.comet_project,
             comet_workspace=args.comet_workspace,

--- a/scripts_python/tests/t_batch_sampler_iter.py
+++ b/scripts_python/tests/t_batch_sampler_iter.py
@@ -74,7 +74,7 @@ def t_non_lazy(args):
     print('Initializing dataset...')
     dataset = MultiSubjectDataset(args.hdf5_filename, lazy=False,
                                   experiment_name='test',
-                                  taskman_managed=True, cache_size=None)
+                                  taskman_managed=True, subset_cache_size=None)
     dataset.load_data()
 
     print('\n=============================Test with batch size 1000')
@@ -100,7 +100,7 @@ def t_lazy(args):
     print('Initializing dataset...')
     dataset = MultiSubjectDataset(args.hdf5_filename, lazy=True,
                                   experiment_name='test',
-                                  taskman_managed=True, cache_size=1)
+                                  taskman_managed=True, subset_cache_size=1)
     dataset.load_data()
 
     print('\n=============================Test with batch size 1000')

--- a/scripts_python/tests/t_batch_sampler_load_batch.py
+++ b/scripts_python/tests/t_batch_sampler_load_batch.py
@@ -160,7 +160,7 @@ def t_non_lazy(args, affine, header):
     logging.root.setLevel('INFO')
     dataset = MultiSubjectDataset(args.hdf5_filename, lazy=False,
                                   experiment_name='test',
-                                  taskman_managed=True, cache_size=None)
+                                  taskman_managed=True, subset_cache_size=None)
     dataset.load_data()
 
     print('\n\n===================== A. Test with reverse + split')
@@ -188,8 +188,8 @@ def t_lazy(args, affine, header):
     print('Initializing dataset...')
     logging.root.setLevel('INFO')
     dataset = MultiSubjectDataset(args.hdf5_filename, lazy=True,
-                                       experiment_name='test',
-                                       taskman_managed=True, cache_size=1)
+                                  experiment_name='test',
+                                  taskman_managed=True, subset_cache_size=1)
     dataset.load_data()
 
     print('\n\n\n=================== A. Test with basic args')

--- a/scripts_python/tests/t_multisubjectdataset_creation_from_hdf5.py
+++ b/scripts_python/tests/t_multisubjectdataset_creation_from_hdf5.py
@@ -25,7 +25,7 @@ def t_non_lazy(args):
     print("\n\n**========= NON-LAZY =========\n\n")
     fake_dataset = MultiSubjectDataset(args.hdf5_filename, lazy=False,
                                        experiment_name='test',
-                                       taskman_managed=True, cache_size=None)
+                                       taskman_managed=True, subset_cache_size=None)
     fake_dataset.load_data()
 
     print("\n====== Testing properties of the main MultiSubjectDataset: \n")
@@ -43,7 +43,7 @@ def t_non_lazy(args):
     print("  - Volume group, features, streamlines: {}, {}, {}"
           .format(training_set.volume_groups, training_set.nb_features,
                   training_set.streamline_groups))
-    print("  - Cache size: {}".format(training_set.cache_size))
+    print("  - Cache size: {}".format(training_set.subset_cache_size))
     print("  - Total nb streamlines: {}"
           .format(training_set.total_nb_streamlines))
     print("  - Lengths: {}".format(training_set.streamline_lengths))
@@ -88,7 +88,7 @@ def t_lazy(args):
     print("\n\n**========= LAZY =========\n\n")
     fake_dataset = MultiSubjectDataset(args.hdf5_filename, lazy=True,
                                        experiment_name='test',
-                                       taskman_managed=True, cache_size=1)
+                                       taskman_managed=True, subset_cache_size=1)
     fake_dataset.load_data()
     training_set = fake_dataset.training_set
 


### PR DESCRIPTION
Now that we don't use yaml, defaults can safely be added back in class instantiation. 

Scripts has args for all variables anyway, but helps for faster testing, and removes pycharm warning in some cases when setting a variable to None.