### PR TITLE
Remove basicConfig usage

### DIFF
--- a/dwi_ml/experiment_utils/tqdm_logging.py
+++ b/dwi_ml/experiment_utils/tqdm_logging.py
@@ -86,7 +86,7 @@ def logging_redirect_tqdm(
     LOG = logging.getLogger(__name__)
 
     if __name__ == '__main__':
-        logging.basicConfig(level=logging.INFO)
+        logging.getLogger().setLevel(level=logging.INFO)
         with logging_redirect_tqdm():
             for i in trange(9):
                 if i == 4:

--- a/dwi_ml/unit_tests/analyze_batch_loader_visually.py
+++ b/dwi_ml/unit_tests/analyze_batch_loader_visually.py
@@ -114,5 +114,5 @@ def _load_directly_and_verify(batch_loader, batch_idx_tuples, ref):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level='DEBUG')
+    logging.getLogger().setLevel(level='DEBUG')
     save_loaded_batch_for_visual_assessment()

--- a/dwi_ml/unit_tests/test_batch_loader.py
+++ b/dwi_ml/unit_tests/test_batch_loader.py
@@ -18,7 +18,7 @@ SPLIT_RATIO = 0.5
 def test_batch_loader():
     data_dir = fetch_testing_data()
 
-    logging.basicConfig(level=logging.INFO)
+    logging.getLogger().setLevel(level=logging.INFO)
 
     # Change to true to allow debug mode: saves the mask for visual assessment.
     # Requires a reference.
@@ -158,7 +158,7 @@ def _verify_loaded_batch(batch, expected_nb_streamlines, split_ratio):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level='INFO')
+    logging.getLogger().setLevel(level='INFO')
     # Silencing SFT's logger if our logging is in DEBUG mode, because it
     # typically produces a lot of outputs!
     set_sft_logger_level('WARNING')

--- a/dwi_ml/unit_tests/test_batch_sampler.py
+++ b/dwi_ml/unit_tests/test_batch_sampler.py
@@ -106,5 +106,5 @@ def iterate_on_sampler_and_verify(
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level='DEBUG')
+    logging.getLogger().setLevel(level='DEBUG')
     test_batch_sampler()

--- a/dwi_ml/unit_tests/test_dataset.py
+++ b/dwi_ml/unit_tests/test_dataset.py
@@ -169,5 +169,5 @@ def _lazy_version(hdf5_filename):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level='DEBUG')
+    logging.getLogger().setLevel(level='DEBUG')
     test_multisubjectdataset()

--- a/dwi_ml/unit_tests/test_embeddings.py
+++ b/dwi_ml/unit_tests/test_embeddings.py
@@ -37,7 +37,7 @@ def _verify_all_outputs(input_data, keys_to_embeddings, nb_features):
 
 
 def test_embeddings():
-    logging.basicConfig(level='DEBUG')
+    logging.getLogger().setLevel(level='DEBUG')
 
     logging.debug("Unit test: embeddings on tensors")
 

--- a/dwi_ml/unit_tests/test_losses.py
+++ b/dwi_ml/unit_tests/test_losses.py
@@ -39,7 +39,7 @@ Included tests are:
 tol = 1e-5
 d = 3
 
-logging.basicConfig(level='DEBUG')
+logging.getLogger().setLevel(level='DEBUG')
 
 
 def _independent_gaussian_log_prob_vector(x, mus, sigmas):

--- a/dwi_ml/unit_tests/test_models_and_trainer.py
+++ b/dwi_ml/unit_tests/test_models_and_trainer.py
@@ -16,8 +16,6 @@ batch_size_units = 'nb_streamlines'
 
 
 def test_trainer_and_models():
-    # logging.basicConfig(level='DEBUG')
-
     data_dir = fetch_testing_data()
 
     hdf5_filename = os.path.join(data_dir, 'hdf5_file.hdf5')
@@ -77,5 +75,5 @@ def _create_trainer(batch_sampler, batch_loader, model):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level='INFO')
+    logging.getLogger().setLevel(level='INFO')
     test_trainer_and_models()

--- a/dwi_ml/unit_tests/test_models_learn2track.py
+++ b/dwi_ml/unit_tests/test_models_learn2track.py
@@ -81,6 +81,6 @@ def test_learn2track():
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level='DEBUG')
+    logging.getLogger().setLevel(level='DEBUG')
     test_stacked_rnn()
     test_learn2track()

--- a/dwi_ml/unit_tests/test_models_transformers.py
+++ b/dwi_ml/unit_tests/test_models_transformers.py
@@ -104,5 +104,5 @@ def test_models():
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level='DEBUG')
+    logging.getLogger().setLevel(level='DEBUG')
     test_models()

--- a/dwi_ml/unit_tests/test_neighborhood.py
+++ b/dwi_ml/unit_tests/test_neighborhood.py
@@ -73,6 +73,6 @@ def test_neighborhood_interpolation():
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level='DEBUG')
+    logging.getLogger().setLevel(level='DEBUG')
     test_neighborhood_interpolation()
     test_neighborhood_vectors()

--- a/dwi_ml/unit_tests/test_packing.py
+++ b/dwi_ml/unit_tests/test_packing.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 from torch.nn.utils.rnn import pack_sequence, pad_packed_sequence
 
-logging.basicConfig(level='INFO')
+logging.getLogger().setLevel(level='INFO')
 
 
 def test_packing_unpacking():

--- a/scripts_python/dwiml_create_hdf5_dataset.py
+++ b/scripts_python/dwiml_create_hdf5_dataset.py
@@ -52,7 +52,7 @@ def main():
     args = p.parse_args()
 
     # Initialize logger
-    logging.basicConfig(level=str(args.logging).upper())
+    logging.getLogger().setLevel(level=str(args.logging).upper())
 
     # Silencing SFT's logger if our logging is in DEBUG mode, because it
     # typically produces a lot of outputs!

--- a/scripts_python/dwiml_visualize_logs.py
+++ b/scripts_python/dwiml_visualize_logs.py
@@ -36,7 +36,7 @@ def parse_args():
 
 def main():
     args = parse_args()
-    logging.basicConfig(level=logging.INFO)
+    logging.getLogger().setLevel(level=logging.INFO)
 
     path = args.path
 

--- a/scripts_python/l2t_resume_training_from_checkpoint.py
+++ b/scripts_python/l2t_resume_training_from_checkpoint.py
@@ -75,7 +75,7 @@ def main():
 
     # Setting root logger with high level but we will set trainer to
     # user-defined level.
-    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger().setLevel(level=logging.WARNING)
 
     # Verify if a checkpoint has been saved. Else create an experiment.
     if not os.path.exists(os.path.join(

--- a/scripts_python/l2t_track_from_model.py
+++ b/scripts_python/l2t_track_from_model.py
@@ -164,7 +164,7 @@ def main():
     root_level = args.logging
     if root_level == logging.DEBUG:
         root_level = logging.INFO
-    logging.basicConfig(level=root_level)
+    logging.getLogger().setLevel(level=root_level)
 
     # ----- Checks
     if not nib.streamlines.is_supported(args.out_tractogram):

--- a/scripts_python/l2t_train_model.py
+++ b/scripts_python/l2t_train_model.py
@@ -107,7 +107,7 @@ def main():
     if args.logging == 'DEBUG':
         sub_loggers_level = 'INFO'
 
-    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger().setLevel(level=logging.WARNING)
 
     # Check that all files exist
     assert_inputs_exist(p, [args.hdf5_file])

--- a/scripts_python/tests/scripts_on_test_model/dwiml_resume_training_from_checkpoint.py
+++ b/scripts_python/tests/scripts_on_test_model/dwiml_resume_training_from_checkpoint.py
@@ -78,7 +78,7 @@ def main():
 
     # Setting root logger with high level but we will set trainer to
     # user-defined level.
-    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger().setLevel(level=logging.WARNING)
 
     # Verify if a checkpoint has been saved. Else create an experiment.
     if not os.path.exists(os.path.join(

--- a/scripts_python/tests/scripts_on_test_model/dwiml_track_from_model.py
+++ b/scripts_python/tests/scripts_on_test_model/dwiml_track_from_model.py
@@ -195,7 +195,7 @@ def main():
     root_level = args.logging
     if root_level == logging.DEBUG:
         root_level = logging.INFO
-    logging.basicConfig(level=root_level)
+    logging.getLogger().setLevel(level=root_level)
 
     # ----- Checks
     if not nib.streamlines.is_supported(args.out_tractogram):

--- a/scripts_python/tto_resume_training_from_checkpoint.py
+++ b/scripts_python/tto_resume_training_from_checkpoint.py
@@ -96,7 +96,7 @@ def main():
     logging_level = args.logging_choice.upper()
     if args.logging_choice == 'as_much_as_possible':
         logging_level = 'DEBUG'
-    logging.basicConfig(level=logging_level)
+    logging.getLogger().setLevel(level=logging_level)
 
     # Verify if a checkpoint has been saved. Else create an experiment.
     if not os.path.exists(os.path.join(

--- a/scripts_python/ttst_resume_training_from_checkpoint.py
+++ b/scripts_python/ttst_resume_training_from_checkpoint.py
@@ -96,7 +96,7 @@ def main():
     logging_level = args.logging_choice.upper()
     if args.logging_choice == 'as_much_as_possible':
         logging_level = 'DEBUG'
-    logging.basicConfig(level=logging_level)
+    logging.getLogger().setLevel(level=logging_level)
 
     # Verify if a checkpoint has been saved. Else create an experiment.
     if not os.path.exists(os.path.join(


### PR DESCRIPTION
Remove broken basicConfig usage. Depends too much on imported libraries. Ex: Dipy 1.5. breaks the basicConfig.

