### PR TITLE
Change Scilpy version

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -27,7 +27,6 @@ jobs:
       run: |
         # python -m pip install --upgrade --user pip
         # pip install pytest
-        pip install -r requirements_github.txt
         pip install -r requirements.txt
         pip install .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 # Supported for python > 3.7
-# Scilpy must be installed manually first.
-# (or run pip install -r requirements_github.txt)
-
+git+https://github.com/scilus/scilpy.git@1.4.0#egg=scilpy
 
 torch>=1.11.0
 tqdm>=4.60.0

--- a/requirements_github.txt
+++ b/requirements_github.txt
@@ -1,1 +1,0 @@
-git+https://github.com/scilus/scilpy.git@master#egg=scilpy


### PR DESCRIPTION
Latest official release should be ok for current uses.

Scilpy is about to change a lot, so for now, it's better to stop following the master branch.