### PR TITLE
Restrict tests to python 3.7

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -11,7 +11,7 @@ jobs:
       # max-parallel: 6
       matrix:
         os: [ubuntu-18.04]  # or ubuntu-latest
-        python-version: [3.7, 3.8]
+        python-version: [3.7] # , 3.8
         requires: ['latest']
 
     steps:
@@ -27,6 +27,7 @@ jobs:
       run: |
         # python -m pip install --upgrade --user pip
         # pip install pytest
+        pip install --upgrade pip
         pip install -r requirements.txt
         pip install .
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -12,7 +12,9 @@ required dependencies::
 Installing dependencies
 ***********************
 
-The toolkit relies on `Scilpy`_ and on a number of other packages available through the `Python Package Index (PyPI)`_.
+We support python 3.7.  (python3.7-distutils and python3.7-dev must also be installed).
+
+The toolkit relies on `Scilpy`_ and on a number of other packages available through the `Python Package Index (PyPI)`_ (i.e. you can use pip).
 
 We strongly recommend working in a virtual environment to install all
 dependencies related to DWI_ML.


### PR DESCRIPTION
It is an absolute mystery why previous tests worked for python 3.8. It does not locally. Scilpy does not support >3.7 right now.