### PR TITLE
Downgrading torch

### DIFF
--- a/dwi_ml/models/main_models.py
+++ b/dwi_ml/models/main_models.py
@@ -9,8 +9,8 @@ from typing import List, Union
 
 import numpy as np
 import torch
-from torch.nn.utils.rnn import pack_sequence, PackedSequence, \
-    unpack_sequence
+from torch.nn.utils.rnn import pack_sequence, PackedSequence
+from tmp_torch.rnn import unpack_sequence
 
 from dwi_ml.data.processing.volume.interpolation import \
     interpolate_volume_in_neighborhood
@@ -379,8 +379,8 @@ class ModelWithPreviousDirections(MainModelAbstract):
             # We could loop on all lists and embed each.
             # Probably faster to pack result, run model once on all points
             # and unpack later.
-            n_prev_dirs_packed = pack_sequence(n_prev_dirs,
-                                               enforce_sorted=False)
+            n_prev_dirs_packed = pack_sequence(
+                [torch.tensor(p) for p in n_prev_dirs], enforce_sorted=False)
 
             n_prev_dirs = n_prev_dirs_packed.data
             n_prev_dirs.to(self.device)

--- a/dwi_ml/models/projects/transformers.py
+++ b/dwi_ml/models/projects/transformers.py
@@ -4,16 +4,17 @@ from typing import Union, List
 
 import numpy as np
 import torch
-from dwi_ml.data.processing.streamlines.post_processing import \
-    compute_directions
 from torch.nn import Dropout
 from torch.nn.functional import pad
 from torch.nn.modules.transformer import (
     Transformer,
     TransformerEncoder, TransformerDecoder,
     TransformerEncoderLayer, TransformerDecoderLayer)
-from torch.nn.utils.rnn import pack_sequence, PackedSequence, unpack_sequence
+from torch.nn.utils.rnn import pack_sequence, PackedSequence
+from tmp_torch.rnn import unpack_sequence
 
+from dwi_ml.data.processing.streamlines.post_processing import \
+    compute_directions
 from dwi_ml.models.main_models import (MainModelOneInput,
                                        ModelForTracking,
                                        ModelWithPreviousDirections,

--- a/dwi_ml/training/utils/batch_loaders.py
+++ b/dwi_ml/training/utils/batch_loaders.py
@@ -64,7 +64,7 @@ def add_args_batch_loader(p: argparse.ArgumentParser):
 
 def prepare_batch_loader(dataset, model, args, sub_loggers_level):
     # Preparing the batch loader.
-    with Timer("\nPreparing batch loader...", newline=True, color='pink'):
+    with Timer("\nPreparing batch loader...", newline=True, color='magenta'):
         batch_loader = DWIMLBatchLoaderOneInput(
             dataset=dataset, model=model,
             input_group_name=args.input_group_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 # Supported for python > 3.7
 git+https://github.com/scilus/scilpy.git@1.4.0#egg=scilpy
 
-torch>=1.11.0
+# A note about torch: We would prefer >=1.11. But for our users installing dwi_ml on ComputeCanada, as
+# is often the case in our lab, torch 1.10 is available only.
+# Note to developers: See tmp_torch. Remove these when torch 1.11 will be available.
+torch==1.10.0
 tqdm>=4.60.0
 comet-ml>=3.0.2
 contextlib2
@@ -10,7 +13,7 @@ nose
 sphinx_rtd_theme # no longer a hard dependency since version 1.4.0
 
 
-## Necessary but should be installed with scilpy (Last check: 03/2022, version 1.2.2):
+## Necessary but should be installed with scilpy (Last check: 01/2023, version 1.4.0):
 matplotlib==2.2.*
 future==0.17.*
 numpy==1.21.*

--- a/tmp_torch/rnn.py
+++ b/tmp_torch/rnn.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import torch
+from torch import Tensor
+from typing import List
+
+from torch.nn.utils.rnn import PackedSequence, pad_packed_sequence
+
+
+def unpad_sequence(padded_sequences: Tensor, lengths: Tensor,
+                   batch_first: bool = False, ) -> List[Tensor]:
+    """
+    Method copied from torch 1.11, waiting for Beluga to upgrade available
+    wheels to 1.11 (current max is 1.10, so we can't install torch 1.11).
+    """
+    unpadded_sequences = []
+
+    if not batch_first:
+        padded_sequences.transpose_(0, 1)
+
+    max_length = padded_sequences.shape[1]
+    idx = torch.arange(max_length)
+
+    for seq, length in zip(padded_sequences, lengths):
+        mask = idx < length
+        unpacked_seq = seq[mask]
+        unpadded_sequences.append(unpacked_seq)
+
+    return unpadded_sequences
+
+
+def unpack_sequence(packed_sequences: PackedSequence) -> List[Tensor]:
+    """
+    Method copied from torch 1.11, waiting for Beluga to upgrade available
+    wheels to 1.11 (current max is 1.10, so we can't install torch 1.11).
+    """
+
+    padded_sequences, lengths = pad_packed_sequence(packed_sequences,
+                                                    batch_first=True)
+    unpacked_sequences = unpad_sequence(padded_sequences, lengths,
+                                        batch_first=True)
+    return unpacked_sequences


### PR DESCRIPTION
Latest torch wheel available in Beluga = 1.10.

Downgrading torch here. 
Method unpack_sequence becomes unavailable. Creating a tmp_torch folder and copying the method. To be deleted the day we can upgrade.