### PR TITLE
Moving streamlines to torch

### DIFF
--- a/dwi_ml/data/processing/space/neighborhood.py
+++ b/dwi_ml/data/processing/space/neighborhood.py
@@ -4,6 +4,7 @@ import logging
 from typing import Iterable, Union
 
 import numpy as np
+import torch
 
 
 def prepare_neighborhood_vectors(neighborhood_type: str, neighborhood_radius):
@@ -142,7 +143,7 @@ def get_neighborhood_vectors_grid(radius_vox_space: int):
 
 
 def extend_coordinates_with_neighborhood(
-        coords: np.ndarray, neighborhood_vectors: np.ndarray):
+        coords: torch.Tensor, neighborhood_vectors: np.ndarray):
     """
     From a list of coordinates and neighborhood vectors (e.g. [up, down, left,
     right]), get a new list of coordinates with all translations applied to all
@@ -161,6 +162,9 @@ def extend_coordinates_with_neighborhood(
         The new coordinates with all N neighbors (N+1 including the original
         coordinates), in the same space and origin as coords.
     """
+    logging.warning("!!!!!!!!!! TODO. Convert neighborhood vectors to torch")
+    neighborhood_vectors = torch.Tensor(neighborhood_vectors)
+
     m_coords = coords.shape[0]
     n_neighbors = neighborhood_vectors.shape[0]
 
@@ -168,6 +172,8 @@ def extend_coordinates_with_neighborhood(
     # original coordinate) before applying translations.
     # coords = [p1 p1... p2 p2 ... ...]'
     flat_coords = np.repeat(coords, n_neighbors + 1, axis=0)
+    logging.warning("flat_coords {}".format(flat_coords.shape))
+    exit(1)
 
     # 2. We translate each point based on the translations vector.
     # Ex, if neighborhood_translations = [here, up, down, left, right, ...]

--- a/dwi_ml/data/processing/space/neighborhood.py
+++ b/dwi_ml/data/processing/space/neighborhood.py
@@ -23,7 +23,7 @@ def prepare_neighborhood_vectors(neighborhood_type: str, neighborhood_radius):
 
     Returns
     -------
-    neighborhood_vectors: np.ndarray[float] with shape (N, 3).
+    neighborhood_vectors: tensor of shape (N, 3).
         Results are vectors pointing to a neighborhood point, starting from the
         origin (i.e. current position). The current point (0,0,0) is NOT
         included.
@@ -84,7 +84,7 @@ def get_neighborhood_vectors_axes(radius: Union[float, Iterable[float]]):
 
     Returns
     -------
-    neighborhood_vectors : np.ndarray[float] with shape (N, 3)
+    neighborhood_vectors : tensor of shape (N, 3)
         A list of vectors with last dimension = 3 (x,y,z coordinate for each
         neighbour per respect to the origin). The current point (0,0,0) is NOT
         included.
@@ -98,7 +98,7 @@ def get_neighborhood_vectors_axes(radius: Union[float, Iterable[float]]):
     neighborhood_vectors = []
     for r in radius:
         neighborhood_vectors.extend(unit_axes * r)
-    neighborhood_vectors = np.asarray(neighborhood_vectors)
+    neighborhood_vectors = torch.tensor(neighborhood_vectors)
 
     return neighborhood_vectors
 
@@ -121,7 +121,7 @@ def get_neighborhood_vectors_grid(radius_vox_space: int):
 
     Returns
     -------
-    neighborhood_vectors : np.ndarray[float] with shape (N, 3)
+    neighborhood_vectors : tensor shape (N, 3)
         A list of vectors with last dimension = 3 (x,y,z coordinate for each
         neighbour per respect to the origin). The current point (0,0,0) is NOT
         included.
@@ -137,13 +137,13 @@ def get_neighborhood_vectors_grid(radius_vox_space: int):
     for x, y, z in itertools.product(the_range, the_range, the_range):
         if not (x == y == z == 0):  # Not adding origin; not a neighbor
             neighborhood_vectors.append([x, y, z])
-    neighborhood_vectors = np.asarray(neighborhood_vectors)
+    neighborhood_vectors = torch.tensor(neighborhood_vectors)
 
     return neighborhood_vectors
 
 
 def extend_coordinates_with_neighborhood(
-        coords: torch.Tensor, neighborhood_vectors: np.ndarray):
+        coords: torch.Tensor, neighborhood_vectors: torch.tensor):
     """
     From a list of coordinates and neighborhood vectors (e.g. [up, down, left,
     right]), get a new list of coordinates with all translations applied to all
@@ -151,9 +151,9 @@ def extend_coordinates_with_neighborhood(
 
     Parameters
     ------
-    coords: np.ndarray with shape (M, 3)
+    coords: tensor of shape (M, 3)
         An array of M points; [x,y,z] coordinates.
-    neighborhood_vectors: np.ndarray[float] with shape (N, 3)
+    neighborhood_vectors: tensor of shape (N, 3)
         A list of translation vectors to apply to each point in coords.
 
     Returns
@@ -167,17 +167,17 @@ def extend_coordinates_with_neighborhood(
 
     # 1. We repeat each coordinate to have the neighborhood size (+ 1 for
     # original coordinate) before applying translations.
-    # coords = [p1 p1... p2 p2 ... ...]'
-    flat_coords = np.repeat(coords, n_neighbors + 1, axis=0)
-    logging.warning("flat_coords {}".format(flat_coords.shape))
-    exit(1)
+    # coords = [p1 p1... p2 p2 ... ...]'  (Size = [n, 3])
+    flat_coords = coords.repeat_interleave(n_neighbors + 1, dim=0)
 
     # 2. We translate each point based on the translations vector.
     # Ex, if neighborhood_translations = [here, up, down, left, right, ...]
     # coords = [p1+0 p1+up p1+down ..., p2+0 p2+up, p2+down, ...]'
-    total_neighborhood = np.concatenate((np.zeros((1, 3)),
-                                         neighborhood_vectors))
-    tiled_vectors = np.tile(total_neighborhood, (m_coords, 1))
+    # toDo. This "cat" happens every iteration. We can include it in
+    #  neighborhood vectors.
+    total_neighborhood = torch.cat((torch.zeros(1, 3),
+                                    neighborhood_vectors))
+    tiled_vectors = torch.tile(total_neighborhood, (m_coords, 1))
     flat_coords += tiled_vectors
 
     return flat_coords, tiled_vectors

--- a/dwi_ml/data/processing/space/neighborhood.py
+++ b/dwi_ml/data/processing/space/neighborhood.py
@@ -98,7 +98,7 @@ def get_neighborhood_vectors_axes(radius: Union[float, Iterable[float]]):
     neighborhood_vectors = []
     for r in radius:
         neighborhood_vectors.extend(unit_axes * r)
-    neighborhood_vectors = torch.tensor(neighborhood_vectors)
+    neighborhood_vectors = torch.tensor(np.asarray(neighborhood_vectors))
 
     return neighborhood_vectors
 
@@ -158,9 +158,12 @@ def extend_coordinates_with_neighborhood(
 
     Returns
     -------
-    flat_coords: np.ndarray[float] with shape (M x (N+1), 3)
+    flat_coords: tensor of shape (M x (N+1), 3)
         The new coordinates with all N neighbors (N+1 including the original
         coordinates), in the same space and origin as coords.
+    tiled_vectors: tensor
+        The coordinates of neighbors per respect to the current coordinate
+        (translation vectors).
     """
     m_coords = coords.shape[0]
     n_neighbors = neighborhood_vectors.shape[0]

--- a/dwi_ml/data/processing/space/neighborhood.py
+++ b/dwi_ml/data/processing/space/neighborhood.py
@@ -162,9 +162,6 @@ def extend_coordinates_with_neighborhood(
         The new coordinates with all N neighbors (N+1 including the original
         coordinates), in the same space and origin as coords.
     """
-    logging.warning("!!!!!!!!!! TODO. Convert neighborhood vectors to torch")
-    neighborhood_vectors = torch.Tensor(neighborhood_vectors)
-
     m_coords = coords.shape[0]
     n_neighbors = neighborhood_vectors.shape[0]
 

--- a/dwi_ml/data/processing/streamlines/post_processing.py
+++ b/dwi_ml/data/processing/streamlines/post_processing.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import torch
 
-
-# toDo See what to do when values do not exist. See discussion here.
-#  https://stats.stackexchange.com/questions/169887/classification-with-partially-unknown-data
+# We could try using nan instead of zeros for non-existing previous dirs...
 DEFAULT_UNEXISTING_VAL = torch.zeros((1, 3), dtype=torch.float32)
 
 
@@ -107,7 +105,7 @@ def _get_one_n_previous_dirs(streamlines_dirs, nb_previous_dirs,
     return n_previous_dirs
 
 
-def compute_directions(streamlines, device=torch.device('cpu')):
+def compute_directions(streamlines):
     """
     Params
     ------
@@ -115,13 +113,7 @@ def compute_directions(streamlines, device=torch.device('cpu')):
             The streamlines (after data augmentation)
     device: torch device
     """
-    # todo Would it be better to cast s as a tensor and use torch.diff?
-    #  in the trainer, when we call this, just one line further we do convert
-    #  streamlines to tensors.
-    batch_directions = [torch.as_tensor(s[1:] - s[:-1],
-                                        dtype=torch.float32,
-                                        device=device)
-                        for s in streamlines]
+    batch_directions = [torch.diff(s, n=1, dim=0) for s in streamlines]
 
     return batch_directions
 

--- a/dwi_ml/data/processing/volume/interpolation.py
+++ b/dwi_ml/data/processing/volume/interpolation.py
@@ -161,9 +161,6 @@ def interpolate_volume_in_neighborhood(
             extend_coordinates_with_neighborhood(coords_vox_corner,
                                                  neighborhood_vectors_vox)
 
-        coords_vox_corner = torch.as_tensor(coords_vox_corner,
-                                            dtype=torch.float, device=device)
-
         # Interpolate signal for each (new) point
         # DWI data features for each neighbor are concatenated.
         # Result is of shape: (M * (N+1), F).

--- a/dwi_ml/models/direction_getter_models.py
+++ b/dwi_ml/models/direction_getter_models.py
@@ -220,18 +220,7 @@ class AbstractDirectionGetterModel(torch.nn.Module):
             next_dirs = self._get_tracking_direction_det(outputs)
         else:
             next_dirs = self._sample_tracking_direction_prob(outputs)
-        return self._format_dirs(next_dirs)
-
-    @staticmethod
-    def _format_dirs(next_dirs):
-        # Bring back to cpu and get dir.
-        next_dirs = next_dirs.cpu().detach().numpy()
-
-        # next_dirs is of size [nb_points, 3]. Considering we are tracking,
-        # nb_points is 1 and we want to separate it into a list of (3,).
-        next_dirs = [x for x in next_dirs]
-
-        return next_dirs
+        return next_dirs.detach()
 
 
 class AbstractRegressionDirectionGetter(AbstractDirectionGetterModel):

--- a/dwi_ml/models/main_models.py
+++ b/dwi_ml/models/main_models.py
@@ -478,9 +478,6 @@ class MainModelOneInput(MainModelAbstract):
         input_mask: tensor or None
             In debugging mode, returns a mask of all voxels used as input.
         """
-        if type(streamlines[0]) != torch.Tensor:
-            logging.warning("!!!!!!!!!!! TO DO!!!. Change to tensor during training too.")
-            streamlines = [torch.tensor(s) for s in streamlines]
         start_time = datetime.now()
 
         # Flatten = concatenate signal for all streamlines to process

--- a/dwi_ml/models/main_models.py
+++ b/dwi_ml/models/main_models.py
@@ -428,7 +428,7 @@ class ModelWithPreviousDirections(MainModelAbstract):
         """
         # Hints : Should start with:
 
-        # target_dirs = compute_directions(target_streamlines, self.device)
+        # target_dirs = compute_directions(target_streamlines)
         # n_prev_dirs_embedded = self.normalize_and_embed_previous_dirs(
         #       target_dirs)
 

--- a/dwi_ml/models/main_models.py
+++ b/dwi_ml/models/main_models.py
@@ -457,8 +457,9 @@ class MainModelOneInput(MainModelAbstract):
 
         Params
         ------
-        streamlines: list
-            The streamlines, IN VOXEL SPACE, CORNER ORIGIN
+        streamlines: list[Tensor]
+            The streamlines, IN VOXEL SPACE, CORNER ORIGIN.
+            Tensors are of shape (nb points, 3).
         subjset: MultisubjectSubset
             The dataset.
         subj: str
@@ -477,11 +478,14 @@ class MainModelOneInput(MainModelAbstract):
         input_mask: tensor or None
             In debugging mode, returns a mask of all voxels used as input.
         """
+        if type(streamlines[0]) != torch.Tensor:
+            logging.warning("!!!!!!!!!!! TO DO!!!. Change to tensor during training too.")
+            streamlines = [torch.tensor(s) for s in streamlines]
         start_time = datetime.now()
 
         # Flatten = concatenate signal for all streamlines to process
         # faster.
-        flat_subj_x_coords = np.concatenate(streamlines, axis=0)
+        flat_subj_x_coords = torch.cat(streamlines, dim=0)
 
         # Getting the subject's volume and sending to CPU/GPU
         # If data is lazy, get volume from cache or send to cache if
@@ -681,8 +685,8 @@ class ModelForTracking(MainModelAbstract):
 
         Returns
         -------
-        next_dir: list[array(3,)]
-            Numpy arrays with x,y,z value, one per streamline data point.
+        next_dir: Tensor(nb_streamlines, 3)
+            Tensors with x,y,z value, one per streamline data point.
         """
         raise NotImplementedError
 

--- a/dwi_ml/models/projects/learn2track_model.py
+++ b/dwi_ml/models/projects/learn2track_model.py
@@ -321,11 +321,11 @@ class Learn2TrackModel(ModelWithPreviousDirections, ModelForTracking,
             # Training
             return model_outputs
 
-    def _run_forward(self, inputs, streamlines, hidden_reccurent_states,
-                     is_tracking):
+    def _run_forward(self, inputs, streamlines: List[torch.Tensor],
+                     hidden_reccurent_states, is_tracking):
 
         if self.nb_previous_dirs > 0:
-            dirs = compute_directions(streamlines, self.device)
+            dirs = compute_directions(streamlines)
 
             logger.debug("*** 1. {} previous dirs - Embedding = {}..."
                          .format(self.nb_previous_dirs,
@@ -386,8 +386,8 @@ class Learn2TrackModel(ModelWithPreviousDirections, ModelForTracking,
         # whole tensor.
         return model_outputs, out_hidden_recurrent_states
 
-    def compute_loss(self, model_outputs: Any, target_streamlines: list,
-                     **kw):
+    def compute_loss(self, model_outputs: Any,
+                     target_streamlines: List[torch.Tensor], **kw):
         """
         Computes the loss function using the provided outputs and targets.
         Returns the mean loss (loss averaged across timesteps and sequences).
@@ -400,7 +400,7 @@ class Learn2TrackModel(ModelWithPreviousDirections, ModelForTracking,
             cosine regression direction getter return a simple Tensor. Please
             make sure that the chosen direction_getter's output size fits with
             the target ou the target's data if it's a PackedSequence.
-        target_streamlines : List
+        target_streamlines : List[tensor]
             The target streamlines for the batch.
 
         Returns
@@ -409,7 +409,7 @@ class Learn2TrackModel(ModelWithPreviousDirections, ModelForTracking,
             The loss between the outputs and the targets, averaged across
             timesteps and sequences.
         """
-        target_dirs = compute_directions(target_streamlines, self.device)
+        target_dirs = compute_directions(target_streamlines)
 
         if self.normalize_targets:
             target_dirs = normalize_directions(target_dirs)

--- a/dwi_ml/models/projects/transforming_tractography.py
+++ b/dwi_ml/models/projects/transforming_tractography.py
@@ -827,6 +827,4 @@ class TransformerSrcAndTgtModel(AbstractTransformerModel):
         # more a "decoder" than an "encoder" in logical meaning.
         kept_outputs = outputs[:, -outputs.shape[1]//2:, :]
 
-        logging.warning("kept outputs: {}".format(kept_outputs))
-
         return kept_outputs, (sa_weights,)

--- a/dwi_ml/models/projects/transforming_tractography.py
+++ b/dwi_ml/models/projects/transforming_tractography.py
@@ -443,7 +443,9 @@ class AbstractTransformerModel(ModelWithPreviousDirections,
             for i in range(nb_streamlines):
                 assert len(batch_streamlines[i]) == len(batch_x[i]), \
                     "During tracking, we expect the streamlines to have the " \
-                    "same number of points as the input."
+                    "same number of points as the input, but we received {} " \
+                    "input points and {} streamline points for streamline " \
+                    "#{}".format(len(batch_x[i]), len(batch_streamlines[i]), i)
         else:
             for i in range(nb_streamlines):
                 assert len(batch_streamlines[i]) == len(batch_x[i]) + 1, \

--- a/dwi_ml/models/projects/transforming_tractography.py
+++ b/dwi_ml/models/projects/transforming_tractography.py
@@ -462,7 +462,7 @@ class AbstractTransformerModel(ModelWithPreviousDirections,
         # Compute targets (= directions).
         # Will be computed again later for loss computation, but ok, should not
         # be too heavy.
-        batch_t = compute_directions(batch_streamlines, self.device)
+        batch_t = compute_directions(batch_streamlines)
 
         # ----------- Ok. Start processing
 

--- a/dwi_ml/tests/unit_tests/test_models_and_trainer.py
+++ b/dwi_ml/tests/unit_tests/test_models_and_trainer.py
@@ -80,8 +80,3 @@ def _create_trainer(batch_sampler, batch_loader, model, experiments_path,
     # Note. toDo Test fails with nb_cpu_processes=1. Why??
 
     return trainer
-
-
-if __name__ == '__main__':
-    logging.getLogger().setLevel(level='INFO')
-    test_trainer_and_models()

--- a/dwi_ml/tests/unit_tests/test_models_transformers.py
+++ b/dwi_ml/tests/unit_tests/test_models_transformers.py
@@ -3,7 +3,6 @@ import logging
 
 import numpy as np
 from torch import Tensor, isnan, set_printoptions
-from dwi_ml.experiment_utils.prints import format_dict_to_str
 
 from dwi_ml.models.projects.transforming_tractography import (
     OriginalTransformerModel, TransformerSrcAndTgtModel)
@@ -17,17 +16,17 @@ def _create_batch():
     flattened_dwi1 = Tensor([[10., 11., 12., 13.],
                              [50., 51., 52., 53.],
                              [60., 62., 62., 63.]])
-    streamline1 = np.asarray([[0.1, 0.2, 0.3],
-                              [1.1, 1.2, 1.3],
-                              [2.1, 2.2, 2.3],
-                              [3.1, 3.2, 3.3]])
+    streamline1 = Tensor([[0.1, 0.2, 0.3],
+                          [1.1, 1.2, 1.3],
+                          [2.1, 2.2, 2.3],
+                          [3.1, 3.2, 3.3]])
 
     # dwi2 : data for the 2 first points
     flattened_dwi2 = Tensor([[10., 11., 12., 13.],
                              [50., 51., 52., 53.]])
-    streamline2 = np.asarray([[10.1, 10.2, 10.3],
-                              [11.1, 11.2, 11.3],
-                              [12.1, 12.2, 12.3]])
+    streamline2 = Tensor([[10.1, 10.2, 10.3],
+                          [11.1, 11.2, 11.3],
+                          [12.1, 12.2, 12.3]])
 
     batch_x_training = [flattened_dwi1, flattened_dwi2]
     batch_s_training = [streamline1, streamline2]

--- a/dwi_ml/tests/unit_tests/test_neighborhood.py
+++ b/dwi_ml/tests/unit_tests/test_neighborhood.py
@@ -29,7 +29,8 @@ def test_neighborhood_vectors():
 
 def test_neighborhood_interpolation():
     # Coords must be of shape (M, 3). Fails if coordinates are ints!
-    current_coords = np.asarray([[10., 10., 10.], [3., 3., 3.]])
+    current_coords = torch.tensor([[10., 10., 10.],
+                                   [3., 3., 3.]])
     m_coords = 2
 
     neighb_vec = prepare_neighborhood_vectors('grid', neighborhood_radius=1)
@@ -57,6 +58,9 @@ def test_neighborhood_interpolation():
     # Without adding coordinates
     interpolated_data, _ = interpolate_volume_in_neighborhood(
         data, current_coords, neighb_vec)
+    logging.warning(data[10, 10, 10])
+    logging.warning(data[3,3,3])
+    logging.warning(interpolated_data)
 
     assert np.array_equal(interpolated_data.shape,
                           [m_coords, (n_neigh + 1) * f_features])

--- a/dwi_ml/tests/unit_tests/test_neighborhood.py
+++ b/dwi_ml/tests/unit_tests/test_neighborhood.py
@@ -58,9 +58,6 @@ def test_neighborhood_interpolation():
     # Without adding coordinates
     interpolated_data, _ = interpolate_volume_in_neighborhood(
         data, current_coords, neighb_vec)
-    logging.warning(data[10, 10, 10])
-    logging.warning(data[3,3,3])
-    logging.warning(interpolated_data)
 
     assert np.array_equal(interpolated_data.shape,
                           [m_coords, (n_neigh + 1) * f_features])

--- a/dwi_ml/tests/utils/data_and_models_for_tests.py
+++ b/dwi_ml/tests/utils/data_and_models_for_tests.py
@@ -57,7 +57,7 @@ class ModelForTest(MainModelOneInput, ModelWithNeighborhood):
 
     def forward(self, x: list):
         _ = self.fake_parameter
-        regressed_dir = [1., 1., 1.]
+        regressed_dir = torch.tensor([1., 1., 1.])
 
         return [regressed_dir for _ in x]
 
@@ -113,7 +113,7 @@ class TrackingModelForTestWithPD(ModelWithPreviousDirections, ModelForTracking,
 
     def get_tracking_directions(self, regressed_dirs, algo):
         if algo == 'det':
-            return regressed_dirs.cpu().detach().numpy()
+            return regressed_dirs.detach()
         elif algo == 'prob':
             raise NotImplementedError(
                 "Our test model uses (fake) regression and does not allow "

--- a/dwi_ml/tests/utils/data_and_models_for_tests.py
+++ b/dwi_ml/tests/utils/data_and_models_for_tests.py
@@ -94,8 +94,8 @@ class TrackingModelForTestWithPD(ModelWithPreviousDirections, ModelForTracking,
         self.instantiate_direction_getter(dg_input_size)
 
     def compute_loss(self, model_outputs: torch.tensor,
-                     target_streamlines: list, **kw):
-        target_dirs = compute_directions(target_streamlines, self.device)
+                     target_streamlines: List[torch.Tensor], **kw):
+        target_dirs = compute_directions(target_streamlines)
 
         if self.normalize_targets:
             target_dirs = normalize_directions(target_dirs)
@@ -126,7 +126,7 @@ class TrackingModelForTestWithPD(ModelWithPreviousDirections, ModelForTracking,
                 hidden_reccurent_states: tuple = None,
                 return_state: bool = False, is_tracking: bool = False,
                 ) -> List[torch.tensor]:
-        target_dirs = compute_directions(target_streamlines, self.device)
+        target_dirs = compute_directions(target_streamlines)
 
         assert len(target_dirs) == len(inputs), \
             ("Error. The target directions contain {} streamlines but the "

--- a/dwi_ml/tracking/projects/transformer_propagator.py
+++ b/dwi_ml/tracking/projects/transformer_propagator.py
@@ -25,4 +25,7 @@ class TransformerPropagator(DWIMLPropagatorOneInput,
                          input_memory=True)
 
     def _call_model_forward(self, inputs, lines):
+        import logging
+        logging.warning("Inputs: {}".format((len(inputs), inputs[0].shape)))
+        logging.warning("Lines: {}".format((len(lines), lines[0].shape)))
         return self.model(inputs, lines, is_tracking=True)

--- a/dwi_ml/tracking/projects/transformer_propagator.py
+++ b/dwi_ml/tracking/projects/transformer_propagator.py
@@ -14,12 +14,12 @@ class TransformerPropagator(DWIMLPropagatorOneInput,
 
     def __init__(self, dataset: MultisubjectSubset, subj_idx: int,
                  model: AbstractTransformerModel, input_volume_group: str,
-                 step_size: float, rk_order: int, algo: str, theta: float,
+                 step_size: float, algo: str, theta: float,
                  device=None):
         super().__init__(input_volume_group=input_volume_group,
                          dataset=dataset, subj_idx=subj_idx, model=model,
-                         step_size=step_size, rk_order=rk_order, algo=algo,
-                         theta=theta, device=device,
+                         step_size=step_size, algo=algo, theta=theta,
+                         device=device,
                          # Always fixed for Transformers:
                          verify_opposite_direction=False,
                          input_memory=True)

--- a/dwi_ml/tracking/projects/transformer_propagator.py
+++ b/dwi_ml/tracking/projects/transformer_propagator.py
@@ -25,7 +25,4 @@ class TransformerPropagator(DWIMLPropagatorOneInput,
                          input_memory=True)
 
     def _call_model_forward(self, inputs, lines):
-        import logging
-        logging.warning("Inputs: {}".format((len(inputs), inputs[0].shape)))
-        logging.warning("Lines: {}".format((len(lines), lines[0].shape)))
         return self.model(inputs, lines, is_tracking=True)

--- a/dwi_ml/tracking/propagator.py
+++ b/dwi_ml/tracking/propagator.py
@@ -18,7 +18,7 @@ logger = logging.getLogger('tracker_logger')
 class DWIMLPropagator(AbstractPropagator):
     """
     Abstract class for propagator object. Responsible for sampling the final
-    direction through Runge-Kutta integration.
+    direction (by running the model).
 
     Differences with traditional tractography (e.g. in scilpy):
         - current data values (ex, fODF, SH) are not known. The method needs to
@@ -35,7 +35,7 @@ class DWIMLPropagator(AbstractPropagator):
     dataset: MultisubjectSubset
 
     def __init__(self, dataset: MultisubjectSubset, subj_idx: int,
-                 model: MainModelAbstract, step_size: float, rk_order: int,
+                 model: MainModelAbstract, step_size: float,
                  algo: str, theta: float, verify_opposite_direction: bool,
                  device=None, normalize_directions: bool = True):
         """
@@ -51,8 +51,6 @@ class DWIMLPropagator(AbstractPropagator):
             Your torch model.
         step_size: float
             The step size for tracking, in voxel space.
-        rk_order: int
-            Order for the Runge Kutta integration.
         algo: str
             'det' or 'prob'
         theta: float
@@ -70,7 +68,7 @@ class DWIMLPropagator(AbstractPropagator):
         """
         # Dataset will be managed differently. Not a DataVolume.
         # torch trilinear interpolation uses origin='corner', space=vox.
-        super().__init__(dataset, step_size, rk_order,
+        super().__init__(dataset, step_size, rk_order=1,
                          space=Space.VOX, origin=Origin('corner'))
 
         self.subj_idx = subj_idx
@@ -116,7 +114,7 @@ class DWIMLPropagator(AbstractPropagator):
             # Remove all handles
             self.dataset.close_all_handles()
 
-    def prepare_forward(self, seeding_pos, multiple_lines=False):
+    def prepare_forward(self, seeding_pos):
         """
         Prepare information necessary at the first point of the
         streamline for forward propagation: v_in and any other information
@@ -124,11 +122,9 @@ class DWIMLPropagator(AbstractPropagator):
 
         Parameters
         ----------
-        seeding_pos: tuple(x,y,z) or List[tuples]
+        seeding_pos: Tensor or List(Tensor)
             The 3D coordinates or, for simultaneous tracking, list of 3D
             coordinates.
-        multiple_lines: bool
-            If true, using version simulteanous tracking.
 
         Returns
         -------
@@ -136,25 +132,20 @@ class DWIMLPropagator(AbstractPropagator):
             Any tracking information necessary for the propagation.
         """
         # Our models should be able to get an initial direction even with no
-        # information about previous inputs.
-        if multiple_lines:
-            return [None for _ in seeding_pos]
-        else:
-            return None
+        # starting information. Override if your model is different.
+        return [None for _ in seeding_pos]
 
-    def prepare_backward(self, line, forward_dir, multiple_lines=False):
+    def prepare_backward(self, lines, forward_dir):
         """
         Preparing backward.
 
         Parameters
         ----------
-        line: List
-            Result from the forward tracking, reversed. Single line: list of
-            coordinates. Simulatenous tracking: list of list of coordinates.
-        forward_dir: ndarray (3,) or List[ndarray]
+        lines: List[Tensor]
+            Result from the forward tracking, reversed. Each tensor is of
+            shape (nb_points, 3).
+        forward_dir: List[Tensor]
             v_in chosen at the forward step.
-        multiple_lines: bool
-            If true, using version simulteanous tracking.
 
         Returns
         -------
@@ -171,21 +162,14 @@ class DWIMLPropagator(AbstractPropagator):
         # backward again with v_in=None. So basically, we will recompute
         # exactly the same model outputs as for the forward. But maybe the
         # sampling will create a new direction.
-        if not multiple_lines:
-            v_in = super().prepare_backward(line, forward_dir)
-
-            # v_in is in double format (np.float64) but it looks like we need
-            # float32.
-            # todo From testing with learn2track. Always true?
-            if v_in is not None:
-                v_in = v_in.astype(np.float32)
-        else:  # simultaneous tracking.
-            v_in = []
-            for i in range(len(line)):
-                this_v_in = super().prepare_backward(line[i], forward_dir[i])
-                if this_v_in is not None:
-                    this_v_in = this_v_in.astype(np.float32)
-                v_in.append(this_v_in)
+        v_in = [None] * len(lines)
+        for i in range(len(lines)):
+            if len(lines[i]) > 1:
+                v_in[i] = lines[i][-1,:] - lines[i][-2,:]
+                if self.normalize_directions:
+                    v_in[i] /= torch.linalg.norm(v_in[i])
+            elif forward_dir[i] is not None:
+                v_in[i] = torch.flip(forward_dir[i], (0,))
 
         return v_in
 
@@ -196,51 +180,51 @@ class DWIMLPropagator(AbstractPropagator):
         """
         pass
 
-    def propagate_multiple_lines(self, lines, n_v_in):
+    def propagate(self, lines, n_v_in):
         """
-        Equivalent of self.propagate() for multiple lines. We do not call
-        super's at it does not support multiple lines. Super's method supports
-        rk order. We don't. We skip this and directly call
-        _sample_next_direction_or_go_straight.
+        Overriding super()'s propagate. We don't support rk orders.
+        We skip this and directly call _sample_next_direction_or_go_straight.
+        Also, in our case, sub-methods return tensors.
 
         Params
         ------
-        line: list[list[ndarrray (3,)]]
-            Current lines.
-        v_in: list[ndarray (3,)]
+        line: List[Tensor]
+            For each streamline, tensor of shape (nb_points, 3).
+        n_v_in: list[ndarray (3,)]
             Previous tracking directions.
 
         Return
         ------
-        n_new_pos: list[ndarray (3,)]
+        n_new_pos: list[Tensor(3,)]
             The new segment position.
-        n_new_dir: list[ndarray (3,)]
+        n_new_dir: list[Tensor(3,)]
             The new segment direction.
-        are_directions_valid: list[bool]
+        valid_dirs: Tensor(nb_streamlines,)
             True if new_dir is valid.
         """
         # Keeping one coordinate per streamline; the last one.
-        # If model needs the streamlines, use current memory.
-        n_pos = [line[-1] for line in lines]
+        n_pos = [line[-1, :] for line in lines]
 
-        assert self.rk_order == 1
+        # Converting n_v_in to the same shape, [nb_streamlines, 3]
+        empty_pos = torch.full((3,), fill_value=torch.nan).to(self.device)
+        n_v_in = [torch.Tensor(v).to(self.device) if v is not None else
+                  empty_pos for v in n_v_in]
+        n_v_in = torch.vstack(n_v_in)
+        if len(n_v_in.shape) == 1:
+            n_v_in = n_v_in[None, :]
 
-        # Equivalent of sample_next_direction_or_go_straight:
-        n_v_out = self._sample_next_direction(n_pos, n_v_in,
-                                              multiple_lines=True)
-        are_directions_valid = np.array([False if v_out is None else True
-                                         for v_out in n_v_out])
+        # Equivalent of sample_next_direction_or_go_straight, but avoiding
+        # loop.
+        n_v_out = self._sample_next_direction(n_pos, n_v_in)
+        valid_dirs = n_v_out[:, 0] != torch.nan
+        n_v_out[~valid_dirs, :] = n_v_in[~valid_dirs, :]
 
-        # toDo. Faster to do one loop?
-        n_new_dir = [n_v_out[i] if are_directions_valid[i] else n_v_in[i]
-                     for i in range(len(n_v_in))]
+        n_new_pos = [n_pos[i] + self.step_size * n_v_out[i] for i in
+                     range(len(n_pos))]
 
-        n_new_pos = [n_pos[i] + self.step_size * np.array(n_new_dir[i])
-                     for i in range(len(lines))]
+        return n_new_pos, n_v_out, valid_dirs
 
-        return n_new_pos, n_new_dir, are_directions_valid
-
-    def _sample_next_direction(self, pos, v_in, multiple_lines=False):
+    def _sample_next_direction(self, n_pos, n_v_in):
         """
         Run the model to get the outputs, and sample a direction based on this
         information. None if the direction is more than theta angle
@@ -250,55 +234,39 @@ class DWIMLPropagator(AbstractPropagator):
 
         Parameters
         ----------
-        pos: ndarray (3,) or list of ndarrays
-            Current tracking position(s).
-        v_in: ndarray (3,) ir list of ndarrays
+        n_pos: List[Tensor]
+            Current tracking position(s). Tensors are of shape (3,).
+        n_v_in: tensor(nb_streamlines, 3)
             Previous tracking direction(s).
-        multiple_lines: bool
-            If true, using version simulteanous tracking.
 
         Return
         -------
-        direction: ndarray (3,) or list of ndarrays
+        next_dirs: tensor(nb_streamlines, 3)
             Valid tracking direction(s). None if no valid direction
             is found. If self.normalize_directions, direction must be
             normalized.
         """
-        if multiple_lines:
-            n_pos = pos
-            n_v_in = v_in
-        else:
-            n_pos = [pos]
-            n_v_in = [v_in]
-
         # Using the forward method to get the outputs.
         model_outputs = self._get_model_outputs_at_pos(n_pos)
 
         start_time = datetime.now()
-        next_dirs = self.model.get_tracking_directions(model_outputs,
-                                                       self.algo)
+        # Input to model is a list of streamlines but output should be
+        # next_dirs = a tensor of shape [nb_streamlines, 3].
+        next_dirs = self.model.get_tracking_directions(model_outputs, self.algo)
         duration_direction_getter = datetime.now() - start_time
+        logging.debug("Time for direction getter: {}s."
+                      .format(duration_direction_getter.total_seconds()))
 
         start_time = datetime.now()
-        for i in range(len(next_dirs)):
-            if self.normalize_directions:
-                next_dirs[i] /= np.linalg.norm(next_dirs[i])
-            # Verify curvature, else return None.
-            # toDo could we find a better solution for proba tracking?
-            #  Resampling until angle < theta? Easy on the sphere (restrain
-            #  probas on the sphere pics inside a cone theta) but what do we do
-            #  for other models? Ex: For the Gaussian direction getter?
-            if n_v_in[i] is not None:
-                next_dirs[i] = self._verify_angle(next_dirs[i], n_v_in[i])
+        if self.normalize_directions:
+            # Will divide along correct axis.
+            norm = torch.linalg.norm(next_dirs, dim=-1)
+            next_dirs = torch.div(next_dirs, norm[:, None])
+        next_dirs = self._verify_angle(next_dirs, n_v_in)
         duration_norm_angle = datetime.now() - start_time
 
-        logging.debug("Time for direction getter: {}s. Time for normalization "
-                      "+ verifying angle: {}s."
-                      .format(duration_direction_getter.total_seconds(),
-                              duration_norm_angle.total_seconds()))
-
-        if not multiple_lines:
-            return next_dirs[0]
+        logging.debug("Time for normalization + verifying angle: {}s."
+                      .format(duration_norm_angle.total_seconds()))
 
         return next_dirs
 
@@ -306,7 +274,7 @@ class DWIMLPropagator(AbstractPropagator):
         """
         Parameters
         ----------
-        n_pos: list of ndarrays
+        n_pos: List[Tensor(1,3)]
             Current position coordinates for each streamline.
         """
         inputs = self._prepare_inputs_at_pos(n_pos)
@@ -323,24 +291,40 @@ class DWIMLPropagator(AbstractPropagator):
     def _prepare_inputs_at_pos(self, pos):
         raise NotImplementedError
 
-    def _verify_angle(self, next_dir, v_in):
+    def _verify_angle(self, next_dirs: torch.Tensor, n_v_in: torch.Tensor):
+        # toDo could we find a better solution for proba tracking?
+        #  Resampling until angle < theta? Easy on the sphere (restrain
+        #  probas on the sphere pics inside a cone theta) but what do we do
+        #  for other models? Ex: For the Gaussian direction getter?
         if self.normalize_directions:
-            cos_angle = np.dot(next_dir, v_in.T)
+            # Already normalized
+            cos_angle = torch.sum(next_dirs * n_v_in)
         else:
-            cos_angle = np.dot(next_dir / np.linalg.norm(next_dir),
-                               v_in.T / np.linalg.norm(v_in))
+            norm1 = torch.linalg.norm(next_dirs, dim=-1)
+            norm2 = torch.linalg.norm(n_v_in, dim=-1)
+            cos_angle = torch.sum(torch.div(next_dirs, norm1[:, None]) *
+                                  torch.div(n_v_in, norm2[:, None]))
 
         # Resolving numerical instabilities:
-        cos_angle = min(max(-1.0, float(cos_angle)), 1.0)
-        angle = np.arccos(cos_angle)
+        # (Converts angle to numpy)
+        # Torch does not have a min() for tensor vs scalar. Using np. Ok,
+        # small step.
+        cos_angle = np.minimum(np.maximum(-1.0, cos_angle.cpu()), 1.0)
+        angle = torch.arccos(cos_angle)
+        if self.verify_opposite_direction:
+            mask_angle = angle > np.pi / 2  # 90 degrees
+            angle[mask_angle] = np.mod(angle[mask_angle] + np.pi, 2*np.pi)
+            next_dirs[mask_angle] = - next_dirs[mask_angle]
 
-        if self.verify_opposite_direction and angle > np.pi / 2:  # 90 degres
-            angle = np.mod(angle + np.pi, 2*np.pi)
-            next_dir = - next_dir
+        mask_angle = angle > self.theta
+        next_dirs[mask_angle] = torch.full((3,), fill_value=torch.nan
+                                           ).to(self.device)
 
-        if angle > self.theta:
-            return None
-        return next_dir
+        return next_dirs
+
+    def finalize_streamline(self, last_pos: torch.Tensor, v_in: torch.Tensor):
+        final_pos = last_pos + self.step_size * v_in
+        return final_pos
 
 
 class DWIMLPropagatorwithStreamlineMemory(DWIMLPropagator):
@@ -362,12 +346,6 @@ class DWIMLPropagatorwithStreamlineMemory(DWIMLPropagator):
         """
         super().__init__(**kw)
 
-        if self.rk_order > 1:
-            logger.warning("dwi_ml with memory of streamlines is not ready "
-                           "for runge-kutta integration. Changing to rk_order "
-                           "1.")
-            self.rk_order = 1
-
         self.use_input_memory = input_memory
 
         self.current_lines = None  # type: Union[List, None]
@@ -377,12 +355,12 @@ class DWIMLPropagatorwithStreamlineMemory(DWIMLPropagator):
         self.input_memory = None  # type: Union[List, None]
         # List of inputs, as formatted by the model.
 
-    def prepare_forward(self, seeding_pos, multiple_lines=False):
+    def prepare_forward(self, seeding_pos):
         self.current_lines = None
         self.input_memory = None
-        return super().prepare_forward(seeding_pos, multiple_lines)
+        return super().prepare_forward(seeding_pos)
 
-    def prepare_backward(self, line, forward_dir, multiple_lines=False):
+    def prepare_backward(self, line, forward_dir):
         # No need to invert the list of coordinates. Will be done by the
         # tracker anyway. We will update it at the next propagate() call.
         # We need to manage the input.
@@ -390,22 +368,18 @@ class DWIMLPropagatorwithStreamlineMemory(DWIMLPropagator):
             self.input_memory = \
                 [torch.flip(line_input, dims=[0])
                  for line_input in self.input_memory]
-        return super().prepare_backward(line, forward_dir, multiple_lines)
+        return super().prepare_backward(line, forward_dir)
 
-    def propagate(self, line, v_in):
-        # Saving the streamline now. We will save the input after computing it.
-        self.current_lines = [line]
-        return super().propagate(line, v_in)
-
-    def propagate_multiple_lines(self, lines, n_v_in):
+    def propagate(self, lines, v_in):
         self.current_lines = lines
-        return super().propagate_multiple_lines(lines, n_v_in)
+
+        return super().propagate(lines, v_in)
 
     def _get_model_outputs_at_pos(self, n_pos):
         """
         Parameters
         ----------
-        n_pos: list of ndarrays
+        n_pos: list[tensor(1,3)]
             Current position coordinates for each streamline.
         """
         inputs = self._prepare_inputs_at_pos(n_pos)
@@ -418,16 +392,13 @@ class DWIMLPropagatorwithStreamlineMemory(DWIMLPropagator):
                     [torch.cat((self.input_memory[i], inputs[i]), dim=0)
                      for i in range(len(self.current_lines))]
 
-        # Todo. This is not perfect yet. Sending data to new device at each
-        #  new point. Could it already be a tensor in memory?
-        lines = [torch.tensor(np.vstack(line)).to(self.device) for
-                 line in self.current_lines]
-
         start_time = datetime.now()
         if self.use_input_memory:
-            model_outputs = self._call_model_forward(self.input_memory, lines)
+            model_outputs = self._call_model_forward(self.input_memory,
+                                                     self.current_lines)
         else:
-            model_outputs = self._call_model_forward(inputs, lines)
+            model_outputs = self._call_model_forward(inputs,
+                                                     self.current_lines)
         duration_running_model = datetime.now() - start_time
 
         logger.debug("Time to run the model: {}"
@@ -483,15 +454,12 @@ class DWIMLPropagatorOneInput(DWIMLPropagator):
 
         Params
         ------
-        pos: list[n x [[x, y, z]]]
+        n_pos: List[Tensor(1, 3)]
             List of n "streamlines" composed of one point.
         """
-        # torch trilinear interpolation uses origin='corner', space=vox.
-        # We're ok.
-        lines = [[point] for point in n_pos]
-
+        n_pos = [pos[None, :] for pos in n_pos]
         inputs, _ = self.model.prepare_batch_one_input(
-            lines, self.dataset, self.subj_idx, self.volume_group,
+            n_pos, self.dataset, self.subj_idx, self.volume_group,
             self.device)
 
         return inputs

--- a/dwi_ml/tracking/tracker.py
+++ b/dwi_ml/tracking/tracker.py
@@ -185,10 +185,6 @@ class DWIMLTracker(ScilpyTracker):
             # Reversing:
             lines = [torch.flip(line, (0,)) for line in lines]
 
-            # We could loop to prepare reverse. Basic case not too heavy.
-            # However, in some cases (ex, projects with memory), model
-            # needs to be re-run before starting back-propagation. We let
-            # the propagator deal with the looping.
             tracking_info = self.propagator.prepare_backward(
                 lines, forward_dir=tracking_info)
 

--- a/dwi_ml/tracking/utils.py
+++ b/dwi_ml/tracking/utils.py
@@ -63,12 +63,6 @@ def add_tracking_options(p):
                          metavar='M',
                          help='Maximum length of a streamline in mm. '
                               '[%(default)s]')
-    track_g.add_argument('--rk_order', metavar="K", type=int, default=2,
-                         choices=[1, 2, 4],
-                         help="The order of the Runge-Kutta integration used "
-                              "for the \nstep function [%(default)s]. As a "
-                              "rule of thumb, doubling the rk_order \nwill "
-                              "double the computation time in the worst case.")
 
     # Additional tracking options compared to scil_compute_local_tracking:
     track_g.add_argument('--theta', metavar='t', type=float,

--- a/dwi_ml/training/trainers.py
+++ b/dwi_ml/training/trainers.py
@@ -1076,9 +1076,6 @@ class DWIMLTrainerOneInput(DWIMLAbstractTrainer):
 
             self.logger.debug('*** Computing forward propagation and loss')
             if self.model.model_uses_streamlines:
-                batch_streamlines = [torch.tensor(s).to(self.device) for s in
-                                     batch_streamlines]
-
                 # Possibly computing directions twice (during forward and loss)
                 # but ok, shouldn't be too heavy. Easier to deal with multiple
                 # project's requirements by sending whole streamlines rather

--- a/dwi_ml/training/trainers.py
+++ b/dwi_ml/training/trainers.py
@@ -1045,9 +1045,8 @@ class DWIMLTrainerOneInput(DWIMLAbstractTrainer):
                 self.logger.debug('Finalizing input data preparation on GPU.')
                 batch_streamlines, final_s_ids_per_subj = data
 
-                # toDo. Could we convert streamlines to tensor already when
-                #  loading, and send to GPU here? Would need to modify methods
-                #  such as extend_neighborhood_with_coords.
+                # Sending to GPU
+                batch_streamlines = [s.to(self.device) for s in batch_streamlines]
 
                 # Getting the inputs points from the volumes. Usually done in
                 # load_batch but we preferred to wait here to have a chance to

--- a/scripts_python/l2t_track_from_model.py
+++ b/scripts_python/l2t_track_from_model.py
@@ -96,7 +96,7 @@ def prepare_tracker(parser, args, device, min_nbr_pts, max_nbr_pts,
             args.step_size, res)
         propagator = RecurrentPropagator(
             subset, subj_idx, model, args.input_group, step_size_vox,
-            args.rk_order, args.algo, theta, device)
+            args.algo, theta, device)
 
         logging.debug("Instantiating tracker.")
         tracker = DWIMLTracker(

--- a/scripts_python/tests/scripts_on_test_model/dwiml_track_from_model.py
+++ b/scripts_python/tests/scripts_on_test_model/dwiml_track_from_model.py
@@ -110,9 +110,8 @@ def prepare_tracker(parser, args, device, min_nbr_pts, max_nbr_pts,
         propagator = TestPropagator(
             input_volume_group=args.input_group,
             dataset=subset, subj_idx=subj_idx, model=model,
-            step_size=step_size_vox, rk_order=args.rk_order,
-            algo=args.algo, theta=theta, device=device,
-            normalize_directions=normalize_directions,
+            step_size=step_size_vox, algo=args.algo, theta=theta,
+            device=device, normalize_directions=normalize_directions,
             verify_opposite_direction=False)
 
         logging.debug("Instantiating tracker.")

--- a/scripts_python/tests/test_all_steps_learn2track.py
+++ b/scripts_python/tests/test_all_steps_learn2track.py
@@ -72,8 +72,8 @@ def test_execution_training_tracking(script_runner, experiments_path):
     ret = script_runner.run(
         'l2t_track_from_model.py', whole_experiment_path, hdf5_file, subj_id,
         out_tractogram, seeding_mask_group, tracking_mask_group, input_group,
-        '--algo', 'det', '--nt', '2', '--rk_order', '1', '--rng_seed', '0',
-        '--min_length', '0', '--subset', 'training')
+        '--algo', 'det', '--nt', '2', '--rng_seed', '0', '--min_length', '0',
+        '--subset', 'training')
 
     assert ret.success
 
@@ -84,9 +84,9 @@ def test_execution_training_tracking(script_runner, experiments_path):
         ret = script_runner.run(
             'l2t_track_from_model.py', whole_experiment_path, hdf5_file,
             subj_id, out_tractogram, seeding_mask_group, tracking_mask_group,
-            input_group, '--algo', 'det', '--nt', '2', '--rk_order', '1',
-            '--rng_seed', '0', '--min_length', '0', '--subset', 'training',
+            input_group, '--algo', 'det', '--nt', '20', '--rng_seed', '0',
+            '--min_length', '0', '--subset', 'training',
             # Additional params compared to CPU:
             '--use_gpu', '--simultaneous_tracking', '3')
 
-        assert ret.success
+        assert False #ret.success

--- a/scripts_python/tests/test_all_steps_learn2track.py
+++ b/scripts_python/tests/test_all_steps_learn2track.py
@@ -89,4 +89,4 @@ def test_execution_training_tracking(script_runner, experiments_path):
             # Additional params compared to CPU:
             '--use_gpu', '--simultaneous_tracking', '3')
 
-        assert False #ret.success
+        assert ret.success

--- a/scripts_python/tests/test_all_steps_tto.py
+++ b/scripts_python/tests/test_all_steps_tto.py
@@ -75,6 +75,6 @@ def test_execution(script_runner, experiments_path):
         'tto_track_from_model.py', whole_experiment_path, hdf5_file, subj_id,
         out_tractogram, seeding_mask_group, tracking_mask_group, input_group,
         '--algo', 'det', '--nt', '2', '--rng_seed', '0',
-        '--min_length', '0', '--subset', 'training')
+        '--min_length', '0', '--subset', 'training', '--logging', 'DEBUG')
 
     assert ret.success

--- a/scripts_python/tests/test_all_steps_tto.py
+++ b/scripts_python/tests/test_all_steps_tto.py
@@ -74,7 +74,7 @@ def test_execution(script_runner, experiments_path):
     ret = script_runner.run(
         'tto_track_from_model.py', whole_experiment_path, hdf5_file, subj_id,
         out_tractogram, seeding_mask_group, tracking_mask_group, input_group,
-        '--algo', 'det', '--nt', '2', '--rk_order', '1', '--rng_seed', '0',
+        '--algo', 'det', '--nt', '2', '--rng_seed', '0',
         '--min_length', '0', '--subset', 'training')
 
     assert ret.success

--- a/scripts_python/tests/test_all_steps_ttst.py
+++ b/scripts_python/tests/test_all_steps_ttst.py
@@ -73,6 +73,6 @@ def test_execution(script_runner, experiments_path):
     ret = script_runner.run(
         'ttst_track_from_model.py', whole_experiment_path, hdf5_file, subj_id,
         out_tractogram, seeding_mask_group, tracking_mask_group, input_group,
-        '--algo', 'det', '--nt', '2', '--rk_order', '1', '--rng_seed', '0',
+        '--algo', 'det', '--nt', '2', '--rng_seed', '0',
         '--min_length', '0', '--subset', 'training')
     assert ret.success

--- a/scripts_python/tto_track_from_model.py
+++ b/scripts_python/tto_track_from_model.py
@@ -100,7 +100,7 @@ def prepare_tracker(parser, args, device,
         propagator = TransformerPropagator(
             dataset=subset, subj_idx=subj_idx, model=model,
             input_volume_group=args.input_group, step_size=step_size_vox,
-            rk_order=args.rk_order, algo=args.algo, theta=theta, device=device)
+            algo=args.algo, theta=theta, device=device)
 
         logging.debug("Instantiating tracker.")
         tracker = DWIMLTracker(

--- a/scripts_python/ttst_track_from_model.py
+++ b/scripts_python/ttst_track_from_model.py
@@ -100,7 +100,7 @@ def prepare_tracker(parser, args, device,
         propagator = TransformerPropagator(
             dataset=subset, subj_idx=subj_idx, model=model,
             input_volume_group=args.input_group, step_size=step_size_vox,
-            rk_order=args.rk_order, algo=args.algo, theta=theta, device=device)
+            algo=args.algo, theta=theta, device=device)
 
         logging.debug("Instantiating tracker.")
         tracker = DWIMLTracker(


### PR DESCRIPTION
## Description
Trying to improve processing time. Using current tests, it does not seem to improve much. But it is now more logical, particularly for transformers: we don't move streamlines back and fourth between CPU and GPU at every propagation step.

Also, simplified propagator: Now we always send multiple streamlines.

