### PR TITLE
ENH: Remove `future` package dependency

### DIFF
--- a/dwi_ml/experiment_utils/tqdm_logging.py
+++ b/dwi_ml/experiment_utils/tqdm_logging.py
@@ -8,7 +8,6 @@ Their class is not ready for comet_ml environment. I have added a PR to their gi
 
 Copying here before it is accepted.
 """
-from __future__ import absolute_import
 
 import logging
 import sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ sphinx_rtd_theme # no longer a hard dependency since version 1.4.0
 
 ## Necessary but should be installed with scilpy (Last check: 03/2022, version 1.2.2):
 matplotlib==2.2.*
-future==0.17.*
 numpy==1.21.*
 scipy==1.4.*
 # h5py must absolutely be >2.4: that's when it became thread-safe


### PR DESCRIPTION
Remove the `future` package dependency: it is no longer required in Python 3, and it is redundant.

Fixes the dependabot security warnings that are being raised weekly.

Documentation:
https://docs.python.org/3/reference/simple_stmts.html#future-statements

## Have you
- [X] Added a description of the content of this PR above
- [X] Followed [proper commit message formatting](https://chris.beams.io/posts/git-commit/)