### PR TITLE
Removing Scilpy's tracker/propagator usage

### DIFF
--- a/dwi_ml/data/processing/volume/interpolation.py
+++ b/dwi_ml/data/processing/volume/interpolation.py
@@ -27,6 +27,30 @@ idx_box = np.array([[0, 0, 0],
                     [1, 1, 1]], dtype=float)
 
 
+def torch_nearest_neighbor_interpolation(volume: torch.Tensor,
+                                         coords_vox_corner: torch.Tensor):
+    """
+    Parameters
+    ----------
+    volume : torch.Tensor with 3D or 4D shape
+        The input volume to interpolate from
+    coords_vox_corner : torch.Tensor with shape (N,3)
+        The coordinates where to interpolate. (Origin = corner, space = vox).
+
+    Returns
+    -------
+    output : torch.Tensor with shape (N, #modalities)
+        The list of interpolated values
+    """
+    # Coord corner: First voxel is coordinates from 0 to 0.99.
+    # Using floor value.
+    coords_vox_corner = torch.floor(coords_vox_corner)
+
+    return volume[coords_vox_corner[:, 0],
+                  coords_vox_corner[:, 1],
+                  coords_vox_corner[:, 2], :]
+
+
 def torch_trilinear_interpolation(volume: torch.Tensor,
                                   coords_vox_corner: torch.Tensor):
     """Evaluates the data volume at given coordinates using trilinear
@@ -55,10 +79,6 @@ def torch_trilinear_interpolation(volume: torch.Tensor,
     ----------
     [1] https://spie.org/samples/PM159.pdf
     """
-    # Get device, and make sure volume and coords are using the same one
-    assert volume.device == coords_vox_corner.device,\
-        "volume on device: {}; " \
-        "coords on device: {}".format(volume.device, coords_vox_corner.device)
     device = volume.device
 
     # Send data to device

--- a/dwi_ml/data/processing/volume/interpolation.py
+++ b/dwi_ml/data/processing/volume/interpolation.py
@@ -44,11 +44,11 @@ def torch_nearest_neighbor_interpolation(volume: torch.Tensor,
     """
     # Coord corner: First voxel is coordinates from 0 to 0.99.
     # Using floor value.
-    coords_vox_corner = torch.floor(coords_vox_corner)
+    coords_vox_corner = torch.floor(coords_vox_corner).to(dtype=torch.long)
 
     return volume[coords_vox_corner[:, 0],
                   coords_vox_corner[:, 1],
-                  coords_vox_corner[:, 2], :]
+                  coords_vox_corner[:, 2]]
 
 
 def torch_trilinear_interpolation(volume: torch.Tensor,

--- a/dwi_ml/experiment_utils/memory.py
+++ b/dwi_ml/experiment_utils/memory.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import logging
-
 import torch
 
 BYTES_IN_GB = 1024 ** 3

--- a/dwi_ml/models/main_models.py
+++ b/dwi_ml/models/main_models.py
@@ -74,7 +74,6 @@ class MainModelAbstract(torch.nn.Module):
 
         Hint: If using a DirectionGetter, see prepare_targets_for_loss.
         """
-        logging.warning("USED ABSTRACT!!!!!!!!!!!!!!!!!!!!!!!!!!")
         return streamlines
 
     def move_to(self, device):
@@ -406,8 +405,7 @@ class ModelWithPreviousDirections(MainModelAbstract):
         else:
             return n_prev_dirs_packed
 
-    def forward(self, inputs, target_streamlines: List[torch.tensor],
-                **kw):
+    def forward(self, inputs, target_streamlines: List[torch.tensor], **kw):
         """
         Params
         ------
@@ -547,7 +545,6 @@ class ModelWithDirectionGetter(MainModelAbstract):
         elif self._context == 'training' and not self.direction_getter.add_eos:
             # We don't use the last coord because it is used only to
             # compute the last target direction, it's not really an input
-            logging.warning("REACHED HERE!!!!!!!!!!!!!!!!!!!!!!!!!!")
             streamlines = [s[:-1, :] for s in streamlines]
         return streamlines
 

--- a/dwi_ml/tests/utils/data_and_models_for_tests.py
+++ b/dwi_ml/tests/utils/data_and_models_for_tests.py
@@ -16,8 +16,6 @@ from dwi_ml.models.main_models import (
     ModelWithPreviousDirections)
 from dwi_ml.tests.utils.expected_values import (
     TEST_EXPECTED_STREAMLINE_GROUPS, TEST_EXPECTED_VOLUME_GROUPS)
-from dwi_ml.tracking.propagator import DWIMLPropagatorwithStreamlineMemory, \
-    DWIMLPropagatorOneInput
 from dwi_ml.training.batch_samplers import DWIMLBatchIDSampler
 from dwi_ml.training.batch_loaders import DWIMLBatchLoaderOneInput
 
@@ -222,9 +220,3 @@ def create_batch_loader(
         reverse_ratio=reverse_ratio, log_level=log_level, model=model)
 
     return batch_loader
-
-
-class TestPropagator(DWIMLPropagatorwithStreamlineMemory,
-                     DWIMLPropagatorOneInput):
-    def __init__(self, **kw):
-        super().__init__(**kw)

--- a/dwi_ml/tracking/projects/transformer_tracker.py
+++ b/dwi_ml/tracking/projects/transformer_tracker.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import torch
+
+from dwi_ml.models.projects.transforming_tractography import AbstractTransformerModel
+from dwi_ml.tracking.tracker import (
+    DWIMLTrackerOneInput, DWIMLTrackerFromWholeStreamline)
+
+
+# Just combining the two Abstract Classes of interest.
+class TransformerTracker(DWIMLTrackerOneInput, DWIMLTrackerFromWholeStreamline):
+    """
+    For the Transformer, we simply need OneInput + StreamlineMemory.
+    """
+    model: AbstractTransformerModel
+
+    def __init__(self, **kw):
+        super().__init__(verify_opposite_direction=False, **kw)
+
+    def _call_model_forward(self, inputs, lines):
+        """Copying super's method but adding is_tracking=True"""
+
+        # Adding the current input to the input memory
+        if len(self.input_memory) == 0:
+            self.input_memory = inputs
+        else:
+            # If they all had the same lengths we could concatenate
+            # everything. But during backward, they don't.
+            self.input_memory = \
+                [torch.cat((self.input_memory[i], inputs[i]), dim=0)
+                 for i in range(len(self.input_memory))]
+
+        import logging
+        logging.warning("INPUT: {}x{}".format(len(self.input_memory), self.input_memory[0].shape))
+        logging.warning("Lines:{}x{}".format(len(lines), lines[0].shape))
+        with self.grad_context:
+            if self.model.forward_uses_streamlines:
+                model_outputs = self.model(self.input_memory, lines,
+                                           is_tracking=True)
+            else:
+                model_outputs = self.model(self.input_memory, is_tracking=True)
+        return model_outputs

--- a/dwi_ml/tracking/tracker.py
+++ b/dwi_ml/tracking/tracker.py
@@ -13,32 +13,73 @@ from dipy.io.stateful_tractogram import Space, Origin
 from dipy.tracking.streamlinespeed import compress_streamlines
 from scilpy.tracking.seed import SeedGenerator
 
-from dwi_ml.tracking.propagator import DWIMLPropagator
+from dwi_ml.data.dataset.multi_subject_containers import MultisubjectSubset
+from dwi_ml.models.main_models import ModelWithDirectionGetter, \
+    MainModelOneInput
 from dwi_ml.tracking.tracking_mask import TrackingMask
 
 logger = logging.getLogger('tracker_logger')
 
 
-class DWIMLTracker:
-    def __init__(self, propagator: DWIMLPropagator, mask: TrackingMask,
-                 seed_generator: SeedGenerator, nbr_seeds, min_nbr_pts,
-                 max_nbr_pts, max_invalid_dirs, compression_th=0.1,
-                 nbr_processes=1, save_seeds=False, rng_seed=1234,
-                 track_forward_only=False, simultanenous_tracking: int = 1,
-                 use_gpu: bool = False, log_level=logging.WARNING):
+class DWIMLAbstractTracker:
+    """
+    Contrary to scilpy: not performing one last step straight when the
+    streamline is finished.
+
+    Abstract version: Uses only the last coordinate of the streamlines in the
+    model to get the next direction.
+    """
+    def __init__(self, dataset: MultisubjectSubset, subj_idx: int,
+                 model: ModelWithDirectionGetter, mask: TrackingMask,
+                 seed_generator: SeedGenerator, nbr_seeds: int,
+                 min_nbr_pts: int, max_nbr_pts: int, max_invalid_dirs: int,
+                 step_size: float, algo: str, theta: float,
+                 verify_opposite_direction: bool,
+                 normalize_directions: bool = True,
+                 compression_th=0.1, nbr_processes=1, save_seeds=False,
+                 rng_seed=1234, track_forward_only=False,
+                 simultanenous_tracking: int = 1, use_gpu: bool = False,
+                 log_level=logging.WARNING):
         """
-        Parameters: See scilpy.
+        Parameters
         ----------
-        propagator: DWIMLPropagator
-            Your propagator.
-        simultaneous_tracking: bool
+        dataset: MultisubjectSubset
+            Loaded testing set. Must be lazy to allow multiprocessing.
+            Multi-subject tracking not implemented; it should contain only
+            one subject.
+        subj_idx: int, subject used for tracking.
+        model: ModelWithDirectionGetter, your torch model.
+        mask: TrackingMask.
+            Can contain no data, but requires its parameter dim to verify if
+            out of bound.
+        seed_generator: SeedGenerator
+        nbr_seeds: int, nb seeds total to track.
+        min_nbr_pts: int, minimal streamline length.
+        max_nbr_pts: int, maximal streamline length.
+        max_invalid_dirs: int
+            Maximal invalid direction. If >1 and a direction is invalid (Ex: If
+            EOS is chosen in a model), the streamline will continue straight
+            until reaching the number of invalid values allowed.
+        step_size: float, the step size for tracking, in voxel space.
+        algo: str, 'det' or 'prob'
+        theta: float
+            Maximum angle (radians) allowed between two steps during sampling
+            of the next direction.
+        verify_opposite_direction: bool
+            If true, during propagation, inverse the direction if opposite
+            direction is better aligned (i.e. data model is symmetrical).
+            If false, your model should learn to guess the correct direction
+            as output.
+        normalize_directions: bool, (if true, normalize directions).
+        compression_th: float, compression threshold.
+        nbr_processes: int, number of CPU processes.
+        save_seeds: bool, wheter to save seeds in the tractogram.
+        rng_seed: float, random seed.
+        track_forward_only: bool.
+        simultanenous_tracking: bool,
             If true, track multiple lines at the same time. Intended for GPU.
         use_gpu: bool
-            New option.
-        hdf_file:
-            Necessary to open a new hdf handle a at process.
         """
-        self.propagator = propagator
         self.mask = mask
         self.seed_generator = seed_generator
         self.nbr_seeds = nbr_seeds
@@ -53,16 +94,41 @@ class DWIMLTracker:
         self.skip = 0  # Not supported yet.
         self.printing_frequency = 1
         self.device = None
+        self.dataset = dataset
+        self.step_size = step_size
+        self.subj_idx = subj_idx
+        self.model = model
+
+        self.algo = algo
+        if algo not in ['det', 'prob']:
+            raise ValueError("Propagator's algo should be 'det' or 'prob'.")
+
+        self.theta = theta
+        self.normalize_directions = normalize_directions
+        if not normalize_directions and step_size != 1:
+            logging.warning("Tracker not normalizing directions obtained as "
+                            "output from the model. Using a step size other "
+                            "than 1 does not really make sense. You probably "
+                            "want to advance of exactly 1 * output.")
+
+        # If output is already normalized, no need to do it again.
+        if 'regression' in self.model.direction_getter.key and \
+                self.model.direction_getter.normalize_outputs == 1:
+            self.normalize_directions = False
+
+        # Contrary to super: normalize direction is optional
+        self.normalize_directions = normalize_directions
+        self.verify_opposite_direction = verify_opposite_direction
+
+        # -------- Context
+        # Uses torch's module eval(), which "turns off" the training mode.
+        self.model.eval()
+        self.grad_context = torch.no_grad()
 
         # Space and origin
-        self.origin = self.propagator.origin
-        self.space = self.propagator.space
-        assert self.space == Space.VOX
-        assert self.origin == Origin('corner')
-        if (seed_generator.origin != propagator.origin or
-                seed_generator.space != propagator.space):
-            raise ValueError("Seed generator and propagator must work with "
-                             "the same space and origin!")
+        # torch trilinear interpolation uses origin='corner', space=vox.
+        self.origin = Origin('corner')
+        self.space = Space.VOX
 
         # Nb points
         if self.min_nbr_pts <= 0:
@@ -73,7 +139,7 @@ class DWIMLTracker:
         # Either GPU or multi-processes
         self.nbr_processes = self._set_nbr_processes(nbr_processes)
         if nbr_processes > 2:
-            if not propagator.dataset.is_lazy:
+            if not dataset.is_lazy:
                 raise ValueError("Multiprocessing only works with lazy data.")
             if use_gpu:
                 raise ValueError("You cannot use both multi-processes and "
@@ -84,18 +150,19 @@ class DWIMLTracker:
         if use_gpu:
             if torch.cuda.is_available():
                 logging.info("We will be using GPU!")
-                self.move_to(torch.device('cuda'))
+                device = torch.device('cuda')
             else:
                 raise ValueError("You chose GPU (cuda) device but it is not "
                                  "available!")
         else:
-            self.device = torch.device('cpu')
+            device = torch.device('cpu')
+        self.move_to(device)
 
         logger.setLevel(log_level)
 
     def move_to(self, device):
         self.device = device
-        self.propagator.move_to(self.device)  # Sends model and data to device
+        self.model.move_to(device=device)
         self.mask.move_to(device)
         self.max_invalid_dirs.to(device)
 
@@ -155,13 +222,21 @@ class DWIMLTracker:
 
             return lines, seeds
 
+    def reset_data(self):
+        if self.dataset.is_lazy:
+            # Empty cache
+            self.dataset.volume_cache_manager = None
+
+            # Remove all handles
+            self.dataset.close_all_handles()
+
     def _cpu_prepare_multiprocessing_pool(self):
         """
         Prepare multiprocessing pool. We do not need to deal with data
         management, contrary to scilpy.
         """
         # Clearing data from memory
-        self.propagator.reset_data()
+        self.reset_data()
 
         pool = multiprocessing.Pool(self.nbr_processes)
         return pool
@@ -170,7 +245,7 @@ class DWIMLTracker:
         """Nothing to do here. hdf5 deals well with multi-processes."""
 
         logger.info("Preparing for process id {}".format(os.getpid()))
-        self.propagator.reset_data()
+        self.reset_data()
 
     def _cpu_tracking_sub(self, chunk_id):
         """
@@ -239,7 +314,7 @@ class DWIMLTracker:
                 random_generator, indices, first_seed_of_chunk + s)
 
             # Forward and backward tracking
-            line = self._get_multiple_lines_both_directions([seed])[0]
+            line = self._get_multiple_lines_both_directions([seed])[0][0]
 
             if line is not None:
                 streamline = np.array(line, dtype='float32')
@@ -292,7 +367,7 @@ class DWIMLTracker:
 
         return lines, seeds
 
-    def _get_multiple_lines_both_directions(self, n_seeds: List[np.ndarray]):
+    def _get_multiple_lines_both_directions(self, seeds: List[np.ndarray]):
         """
         Params
         ------
@@ -307,42 +382,54 @@ class DWIMLTracker:
         torch.cuda.empty_cache()
 
         # List of list. Sending to torch tensors.
-        n_seeds = [torch.as_tensor(s, device=self.device, dtype=torch.float)
-                   for s in n_seeds]
-        lines = [s.clone()[None, :] for s in n_seeds]
+        seeds = [torch.as_tensor(s, device=self.device, dtype=torch.float)
+                 for s in seeds]
+        lines = [s.clone()[None, :] for s in seeds]
 
         logger.info("Multiple GPU tracking: Starting forward propagation for "
                     "the next {} streamlines.".format(len(lines)))
-        tracking_info = self.propagator.prepare_forward(n_seeds)
-        lines = self._propagate_multiple_lines(lines, tracking_info)
+        initial_dirs = self.prepare_forward(seeds)
+        lines = self._propagate_multiple_lines(lines, initial_dirs)
 
         if not self.track_forward_only:
-            rej_idx = self.propagator.reject_streamlines_before_backward(lines)
-            if rej_idx is not None and len(rej_idx) > 0:
-                lines = [s for i, s in enumerate(lines) if i not in rej_idx]
-                n_seeds = [s for i, s in enumerate(n_seeds) if i not in rej_idx]
+            lines, seeds, backward_dir, _ = self.prepare_backward(
+                lines, seeds, initial_dirs)
 
-            logger.info("   Starting backward propagation for the remaining "
-                        "{} streamlines.".format(len(lines)))
-            # Reversing:
-            lines = [torch.flip(line, (0,)) for line in lines]
-
-            tracking_info = self.propagator.prepare_backward(
-                lines, forward_dir=tracking_info)
-
-            lines = self._propagate_multiple_lines(lines, tracking_info)
+            lines = self._propagate_multiple_lines(lines, backward_dir)
 
         # Clean streamlines
-        # Using max + 1 because we do one last step at the end.
+        # Max is already checked as stopping criteria.
         lengths = np.asarray([len(line) for line in lines])
-        good_lengths = np.logical_and(self.min_nbr_pts <= lengths,
-                                      lengths <= self.max_nbr_pts + 1)
-        good_lengths, = np.where(good_lengths)
+        good_lengths, = np.where(self.min_nbr_pts <= lengths)
         clean_lines = [lines[i] for i in good_lengths]
-        clean_seeds = [n_seeds[i] for i in good_lengths]
+        clean_seeds = [seeds[i] for i in good_lengths]
+
         return clean_lines, clean_seeds
 
-    def _propagate_multiple_lines(self, lines, tracking_info):
+    def prepare_forward(self, seeding_pos):
+        """
+        Prepare information necessary at the first point of the
+        streamline for forward propagation.
+
+        Parameters
+        ----------
+        seeding_pos: Tensor or List(Tensor)
+            The 3D coordinates or, for simultaneous tracking, list of 3D
+            coordinates.
+
+        Returns
+        -------
+        initial_dirs: torch.Tensor
+            Any tracking information necessary for the propagation.
+        """
+        # Our models should be able to get an initial direction even with no
+        # starting information. Override if your model is different.
+        empty_pos = torch.full((3,), fill_value=torch.nan, device=self.device)
+        forward_dirs = torch.tile(empty_pos, (len(seeding_pos), 1))
+
+        return forward_dirs
+
+    def _propagate_multiple_lines(self, lines, initial_dir):
         """
         Equivalent of super's() _propagate_lines() for for multiple tracking at
         the same time (meant to be used on GPU).
@@ -352,7 +439,6 @@ class DWIMLTracker:
         # Monitoring
         invalid_direction_counts = torch.zeros(nb_streamlines,
                                                device=self.device)
-        final_tracking_info = [None] * nb_streamlines  # type: List[torch.Tensor]
         continuing_lines_rawidx = np.arange(nb_streamlines)
 
         # Will get the final lines when they are done.
@@ -362,48 +448,194 @@ class DWIMLTracker:
         # lines.
         all_lines_completed = False
         current_step = 0  # This count is reset for forward and backward
+        previous_dir = initial_dir
         while not all_lines_completed:
             current_step += 1
             logging.debug("Propagation step #{}".format(current_step))
 
-            n_new_pos, tracking_info, valid_dirs = self.propagator.propagate(
-                lines, tracking_info)
+            n_new_pos, previous_dir, valid_dirs = \
+                self.take_one_step_or_go_straight(lines, previous_dir)
 
             # Verifying
             invalid_direction_counts[~valid_dirs] += 1
             can_continue = self._verify_stopping_criteria(
                 invalid_direction_counts, n_new_pos, lines).cpu().numpy()
 
-            # If not ok, that line is finished.
+            # Saving finished streamlines
             new_stopping_lines_raw_idx = continuing_lines_rawidx[~can_continue]
             for i in range(len(lines)):
                 if ~can_continue[i]:
                     final_lines[continuing_lines_rawidx[i]] = lines[i]
-                    final_tracking_info[continuing_lines_rawidx[i]] = \
-                        tracking_info[i]
 
             # Keeping only remaining lines (adding last pos)
             lines = [torch.vstack((s, n_new_pos[i]))
                      for i, s in enumerate(lines) if can_continue[i]]
-            tracking_info = tracking_info[can_continue]
+            previous_dir = previous_dir[can_continue]
             continuing_lines_rawidx = continuing_lines_rawidx[can_continue]
             invalid_direction_counts = invalid_direction_counts[can_continue]
 
             # Update model if needed.
-            self.propagator.multiple_lines_update(
+            self.update_memory_after_removing_lines(
                 can_continue, new_stopping_lines_raw_idx, nb_streamlines)
 
             all_lines_completed = ~np.any(can_continue)
 
         assert len(lines) == 0
         assert len(continuing_lines_rawidx) == 0
-
-        # Possible last step.
-        final_lines = self.propagator.finalize_streamlines(
-            final_lines, final_tracking_info, self.mask)
         assert len(final_lines) == nb_streamlines
 
         return final_lines
+
+    def take_one_step_or_go_straight(self, lines, previous_dirs):
+        """
+        Params
+        ------
+        line: List[Tensor]
+            For each streamline, tensor of shape (nb_points, 3).
+        previous_dirs: Tensor(n, 3)
+            Previous tracking directions. Can contain [NaN, NaN, NaN] for some
+            points.
+
+        Return
+        ------
+        n_new_pos: list[Tensor(3,)]
+            The new segment position.
+        next_dirs: list[Tensor(3,)]
+            The new segment direction. None if no valid direction
+            is found. Normalized if self.normalize_directions.
+        valid_dirs: Tensor(nb_streamlines,)
+            True if new_dir is valid.
+        """
+        last_pos = [line[-1, :] for line in lines]
+
+        # Using the forward method to get the outputs.
+        inputs = self._prepare_inputs_at_pos(last_pos)
+        model_outputs = self._call_model_forward(inputs, lines)
+
+        # Input to model is a list of streamlines but output should be
+        # next_dirs = a tensor of shape [nb_streamlines, 3].
+        next_dirs = self.model.get_tracking_directions(model_outputs,
+                                                       self.algo)
+
+        if self.normalize_directions:
+            # Will divide along correct axis.
+            next_dirs /= torch.linalg.norm(next_dirs, dim=-1)[:, None]
+
+        next_dirs = self._verify_angle(next_dirs, previous_dirs)
+
+        valid_dirs = ~torch.isnan(next_dirs[:, 0])
+        next_dirs[~valid_dirs, :] = previous_dirs[~valid_dirs, :]
+
+        n_new_pos = [last_pos[i] + self.step_size * next_dirs[i, :] for i in
+                     range(len(last_pos))]
+
+        return n_new_pos, next_dirs, valid_dirs
+
+    def _prepare_inputs_at_pos(self, last_pos):
+        raise NotImplementedError
+
+    def _call_model_forward(self, inputs, lines):
+        with self.grad_context:
+            if self.model.forward_uses_streamlines:
+                model_outputs = self.model(inputs, lines)
+            else:
+                model_outputs = self.model(inputs)
+        return model_outputs
+
+    def _verify_angle(self, next_dirs: torch.Tensor,
+                      previous_dirs: torch.Tensor):
+        # toDo could we find a better solution for proba tracking?
+        #  Resampling until angle < theta? Easy on the sphere (restrain
+        #  probas on the sphere pics inside a cone theta) but what do we do
+        #  for other models? Ex: For the Gaussian direction getter?
+        if self.normalize_directions:
+            # Already normalized
+            cos_angle = torch.sum(next_dirs * previous_dirs, dim=1)
+        else:
+            norm1 = torch.linalg.norm(next_dirs, dim=-1)
+            norm2 = torch.linalg.norm(previous_dirs, dim=-1)
+            cos_angle = torch.sum(
+                torch.div(next_dirs, norm1[:, None]) *
+                torch.div(previous_dirs, norm2[:, None]), dim=1)
+
+        # Resolving numerical instabilities:
+        # (Converts angle to numpy)
+        # Torch does not have a min() for tensor vs scalar. Using np. Ok,
+        # small step.
+        cos_angle = np.minimum(np.maximum(-1.0, cos_angle.cpu()), 1.0)
+        angle = torch.arccos(cos_angle)
+
+        if self.verify_opposite_direction:
+            mask_angle = angle > np.pi / 2  # 90 degrees
+            angle[mask_angle] = np.mod(angle[mask_angle] + np.pi, 2*np.pi)
+            next_dirs[mask_angle] = - next_dirs[mask_angle]
+
+        mask_angle = angle > self.theta
+        next_dirs[mask_angle] = torch.full((3,), fill_value=torch.nan,
+                                           device=self.device)
+
+        return next_dirs
+
+    def update_memory_after_removing_lines(
+            self, can_continue: np.ndarray, new_stopping_lines_raw_idx: list,
+            batch_size: int):
+        """
+        In case you need to update your model's memory when removing a
+        streamline.
+        """
+        pass
+
+    def prepare_backward(self, lines, seeds, forward_dir=None):
+        """
+        Preparing backward.
+
+        Parameters
+        ----------
+        lines: List[Tensor]
+            Result from the forward tracking, reversed. Each tensor is of
+            shape (nb_points, 3).
+        seeds: List[ndarray]
+            List of seeds.
+        forward_dir: Tensor
+            First direction chosen at the forward step. Not used here but
+            overwrite if your model needs it.
+
+        Returns
+        -------
+        lines: List
+            Updated streamlines: rejected faild ones + reversed.
+        seeds: List
+            Updated seeds: rejected faild ones.
+        backward_dir: Tensor
+            Initialization direction during forward tracking.
+        idx: List
+            List of rejected indices
+        """
+        # 1) Rejecting streamlines of length 1 (= the seed only). The backward
+        # would produce the same result. Overwrite if your model can change
+        # results when called twice at the same point.
+        lengths = np.asarray([len(s) for s in lines])
+        rej_idx, = np.where(lengths == 1)
+
+        if rej_idx is not None and len(rej_idx) > 0:
+            lines = [s for i, s in enumerate(lines) if i not in rej_idx]
+            seeds = [s for i, s in enumerate(seeds) if i not in rej_idx]
+
+        # 2) If forward tracking succeeded, revert streamlines
+        logger.info("   Starting backward propagation for the remaining "
+                    "{} streamlines.".format(len(lines)))
+        # Reversing:
+        lines = [torch.flip(line, (0,)) for line in lines]
+
+        # 3) New v_in = last direction
+        # Could be the foward_dir inverted, but in our case: always None.
+        # (normalized if self.normalize_directions)
+        backward_dir = [s[-1, :] - s[-2, :] for s in lines]
+        backward_dir = torch.vstack(backward_dir)
+        if self.normalize_directions:
+            backward_dir /= torch.linalg.norm(backward_dir, dim=-1)[:, None]
+
+        return lines, seeds, backward_dir, rej_idx
 
     def _verify_stopping_criteria(self, invalid_direction_count, n_last_pos,
                                   lines):
@@ -425,9 +657,146 @@ class DWIMLTracker:
         can_continue = torch.logical_and(
             can_continue, self.mask.is_vox_corner_in_bound(n_last_pos))
 
-        if self.mask.data is not None:
+        if self.mask.data is not None and torch.any(can_continue):
             # Checking if out of mask
-            can_continue = torch.logical_and(
-                can_continue, self.mask.is_in_mask(n_last_pos))
+            tmp = can_continue.clone()
+            can_continue[tmp] = self.mask.is_in_mask(n_last_pos[tmp])
 
         return can_continue
+
+
+class DWIMLTrackerFromWholeStreamline(DWIMLAbstractTracker):
+    """
+    As compared to the general tracker, here, we need to send the
+    whole streamline to the model in order to generate the next point's
+    position. As it is the tracker's job to generally manage the memory of
+    streamlines, we do not have access to these values. We need to copy
+    them in memory here as long as the streamline is not finished being
+    tracked.
+
+    Parameters
+    ----------
+    use_input_memory: bool
+        Remember the input value(s) at each point (in addition to the
+        streamline itself, i.e. the coordinates, always saved). Warning:
+        could be heavier in memory. Default: False.
+    """
+    def __init__(self, **kw):
+        super().__init__(**kw)
+
+        # List of inputs, as formatted by the model.
+        self.input_memory = []
+
+        # For the backward: either we recompute all inputs, or we need to
+        # remember them during forward everytime a streamline is finished.
+        self.input_memory_for_backward = None
+
+    def prepare_forward(self, seeding_pos):
+        self.input_memory = []
+        self.input_memory_for_backward = [None] * len(seeding_pos)
+        return super().prepare_forward(seeding_pos)
+
+    def prepare_backward(self, lines, seeds, forward_dir=None):
+        lines, seeds, backward_dir, idx = super().prepare_backward(
+            lines, seeds, forward_dir)
+
+        # Reject failed inputs
+        self.input_memory_for_backward = \
+            [s for i, s in enumerate(self.input_memory_for_backward)
+             if i not in idx]
+
+        # Not keeping the initial input point. Backward will start at
+        # that point and will compute it again.
+        self.input_memory = [
+            torch.flip(line_input[1:, :], dims=[0])
+            for line_input in self.input_memory_for_backward]
+        self.input_memory_for_backward = None
+
+        return lines, seeds, forward_dir, idx
+
+    def update_memory_after_removing_lines(
+            self, can_continue: np.ndarray, new_stopping_lines_raw_idx: list,
+            batch_size: int):
+
+        if np.any(~can_continue):
+            stopping_lines_sub_idx, = np.where(~can_continue)
+
+            if self.input_memory_for_backward is not None:
+                # Forward! Saving removed inputs for later.
+                for sr, ss in zip(new_stopping_lines_raw_idx,
+                                  stopping_lines_sub_idx):
+                    self.input_memory_for_backward[sr] = self.input_memory[
+                        ss]
+
+            # Now updating input memory
+            self.input_memory = [self.input_memory[i] for i in
+                                 range(len(can_continue)) if
+                                 can_continue[i]]
+
+    def _call_model_forward(self, inputs, lines):
+
+        # Adding the current input to the input memory
+        if len(self.input_memory) == 0:
+            self.input_memory = inputs
+        else:
+            # If they all had the same lengths we could concatenate
+            # everything. But during backward, they don't.
+            self.input_memory = \
+                [torch.cat((self.input_memory[i], inputs[i]), dim=0)
+                 for i in range(len(self.input_memory))]
+
+        return super()._call_model_forward(self.input_memory, lines)
+
+
+class DWIMLTrackerOneInput(DWIMLAbstractTracker):
+    """
+    This version is for when data is represented as:
+    x: one volume input (formatted through the model, possibly with
+       neighborhood).
+
+    This is in fact similar to our batch sampler (with inputs): it needs to get
+    the data points from the volume (+possibly add a neighborhood) and
+    interpolate the data.
+    """
+    model: MainModelOneInput
+
+    def __init__(self, input_volume_group: str, **kw):
+        """
+        Params
+        ------
+        input_volume_group: str
+            The volume group to use as input in the model.
+        """
+        super().__init__(**kw)
+
+        # During tracking: always computing all inputs, contrary to during
+        # training. Telling model how to format input batch.
+        self.model.skip_input_as_last_point = False
+
+        # Find group index in the data
+        self.volume_group = self.dataset.volume_groups.index(
+            input_volume_group)
+
+        # To help prepare the inputs
+        self.volume_group_str = input_volume_group
+
+        if self.dataset.is_lazy and self.dataset.cache_size == 0:
+            logger.warning("With lazy data and multiprocessing, you should "
+                           "not keep cache size to zero. Data would be "
+                           "loaded again at each propagation step!")
+
+    def _prepare_inputs_at_pos(self, n_pos):
+        """
+        Prepare inputs at current position: get the volume and interpolate at
+        current coordinate (possibly get the neighborhood coordinates too).
+
+        Params
+        ------
+        n_pos: List[Tensor(1, 3)]
+            List of n "streamlines" composed of one point.
+        """
+        n_pos = [pos[None, :] for pos in n_pos]
+        inputs, _ = self.model.prepare_batch_one_input(
+            n_pos, self.dataset, self.subj_idx, self.volume_group)
+
+        return inputs

--- a/dwi_ml/tracking/tracker.py
+++ b/dwi_ml/tracking/tracker.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
+import itertools
 import logging
 import multiprocessing
 import os
+import sys
+import traceback
 from typing import List
 
 import numpy as np
 import torch
 from dipy.io.stateful_tractogram import Space, Origin
+from dipy.tracking.streamlinespeed import compress_streamlines
 from scilpy.image.datasets import DataVolume
-from scilpy.tracking.tracker import Tracker as ScilpyTracker
 from scilpy.tracking.seed import SeedGenerator
 
 from dwi_ml.tracking.propagator import DWIMLPropagator
@@ -16,11 +19,7 @@ from dwi_ml.tracking.propagator import DWIMLPropagator
 logger = logging.getLogger('tracker_logger')
 
 
-class DWIMLTracker(ScilpyTracker):
-    # Removing a few warning by explicitly telling python that the
-    # propagator type is not as in super. Supported in python > 3.5
-    propagator: DWIMLPropagator
-
+class DWIMLTracker:
     def __init__(self, propagator: DWIMLPropagator, mask: DataVolume,
                  seed_generator: SeedGenerator, nbr_seeds, min_nbr_pts,
                  max_nbr_pts, max_invalid_dirs, compression_th=0.1,
@@ -31,7 +30,7 @@ class DWIMLTracker(ScilpyTracker):
         Parameters: See scilpy.
         ----------
         propagator: DWIMLPropagator
-            Now a dwi_ml version of the propagator.
+            Your propagator.
         simultaneous_tracking: bool
             If true, track multiple lines at the same time. Intended for GPU.
         use_gpu: bool
@@ -39,15 +38,39 @@ class DWIMLTracker(ScilpyTracker):
         hdf_file:
             Necessary to open a new hdf handle a at process.
         """
+        self.propagator = propagator
+        self.mask = mask
+        self.seed_generator = seed_generator
+        self.nbr_seeds = nbr_seeds
+        self.min_nbr_pts = min_nbr_pts
+        self.max_nbr_pts = max_nbr_pts
+        self.max_invalid_dirs = max_invalid_dirs
+        self.compression_th = compression_th
+        self.save_seeds = save_seeds
+        self.mmap_mode = None
+        self.rng_seed = rng_seed
+        self.track_forward_only = track_forward_only
+        self.skip = 0  # Not supported yet.
+        self.printing_frequency = 1
 
-        # Warning about the mask being an MRIData instead of DataVolume but
-        # ok! Modified to be able to use as tensor more easily for torch.
-        mmap_mode = None  # Not used here, we deal with hdf5.
-        super().__init__(propagator, mask, seed_generator, nbr_seeds,
-                         min_nbr_pts, max_nbr_pts, max_invalid_dirs,
-                         compression_th, nbr_processes, save_seeds, mmap_mode,
-                         rng_seed, track_forward_only)
+        # Space and origin
+        self.origin = self.propagator.origin
+        self.space = self.propagator.space
+        assert self.space == Space.VOX
+        assert self.origin == Origin('corner')
+        if (seed_generator.origin != propagator.origin or
+                seed_generator.space != propagator.space):
+            raise ValueError("Seed generator and propagator must work with "
+                             "the same space and origin!")
 
+        # Nb points
+        if self.min_nbr_pts <= 0:
+            logging.warning("Minimum number of points cannot be 0. Changed to "
+                            "1.")
+            self.min_nbr_pts = 1
+
+        # Either GPU or multi-processes
+        self.nbr_processes = self._set_nbr_processes(nbr_processes)
         if nbr_processes > 2:
             if not propagator.dataset.is_lazy:
                 raise ValueError("Multiprocessing only works with lazy data.")
@@ -55,10 +78,8 @@ class DWIMLTracker(ScilpyTracker):
                 raise ValueError("You cannot use both multi-processes and "
                                  "gpu.")
 
-        # Set device
         self.simultanenous_tracking = simultanenous_tracking
         self.use_gpu = use_gpu
-
         if use_gpu:
             if torch.cuda.is_available():
                 self.device = torch.device('cuda')
@@ -68,55 +89,174 @@ class DWIMLTracker(ScilpyTracker):
                                  "available!")
         else:
             self.device = torch.device('cpu')
-
-        # Sending model and data to device.
-        self.propagator.move_to(self.device)
+        self.propagator.move_to(self.device)  # Sends model and data to device
 
         logger.setLevel(log_level)
 
-        # Increase the printing frequency as compared to super
-        self.printing_frequency = 1
+    def _set_nbr_processes(self, nbr_processes):
+        """
+        Copied from scilpy's tracker.
 
-        # NOTE: TRAINER USES STREAMLINES COORDINATES IN VOXEL SPACE, TO CORNER.
-        assert self.space == Space.VOX
-        assert self.origin == Origin('corner')
-        assert self.seed_generator.space == Space.VOX
-        assert self.seed_generator.origin == Origin('corner')
+        If user did not define the number of processes, define it automatically
+        (or set to 1 -- no multiprocessing -- if we can't).
+        """
+        if nbr_processes <= 0:
+            try:
+                nbr_processes = multiprocessing.cpu_count()
+            except NotImplementedError:
+                logging.warning("Cannot determine number of cpus: "
+                                "nbr_processes set to 1.")
+                nbr_processes = 1
+
+        if nbr_processes > self.nbr_seeds:
+            nbr_processes = self.nbr_seeds
+            logging.debug("Setting number of processes to {} since there were "
+                          "less seeds than processes.".format(nbr_processes))
+        return nbr_processes
 
     def track(self):
         """
         Scilpy's Tracker.track():
-            - calls _get_streamlines, or
-            - deals with parallel sub-processes and calls _get_streamlines_sub,
-              which call _get_streamlines for each process.
+            - calls _cpu_tracking, or
+            - deals with parallel sub-processes and calls _cpu_tracking_sub,
+              which call _cpu_tracking for each process.
 
         Here adding the GPU usage. Other changes for dwi_ml will be reflected
-        in _get_streamlines.
+        in _cpu_tracking.
         """
         if self.simultanenous_tracking > 1:
-            return self.simultanenous_tracking_on_gpu()
+            return self._gpu_simultanenous_tracking()
         else:
             # On CPU, with possibility of parallel processing.
-            return super().track()
+            # Copied from scilpy's tracker.
+            if self.nbr_processes < 2:
+                chunk_id = 1
+                lines, seeds = self._cpu_tracking(chunk_id)
+            else:
+                # Each process will use get_streamlines_at_seeds
+                chunk_ids = np.arange(self.nbr_processes)
 
-    def _prepare_multiprocessing_pool(self, tmpdir=None):
+                pool = self._cpu_prepare_multiprocessing_pool()
+
+                lines_per_process, seeds_per_process = zip(*pool.map(
+                    self._cpu_tracking_sub, chunk_ids))
+                pool.close()
+                # Make sure all worker processes have exited before leaving
+                # context manager.
+                pool.join()
+                lines = [line for line in itertools.chain(*lines_per_process)]
+                seeds = [seed for seed in itertools.chain(*seeds_per_process)]
+
+            return lines, seeds
+
+    def _cpu_prepare_multiprocessing_pool(self):
         """
         Prepare multiprocessing pool. We do not need to deal with data
         management, contrary to scilpy.
         """
         # Clearing data from memory
-        self.propagator.reset_data(reload_data=False)
+        self.propagator.reset_data()
 
         pool = multiprocessing.Pool(self.nbr_processes)
         return pool
 
-    def _reload_data_for_new_process(self, init_args):
+    def _cpu_reload_data_for_new_process(self):
         """Nothing to do here. hdf5 deals well with multi-processes."""
 
         logger.info("Preparing for process id {}".format(os.getpid()))
-        self.propagator.reset_data(reload_data=True)
+        self.propagator.reset_data()
 
-    def simultanenous_tracking_on_gpu(self):
+    def _cpu_tracking_sub(self, chunk_id):
+        """
+        multiprocessing.pool.map input function. Calls the main tracking
+        method (_cpu_tracking) with correct initialization arguments
+        (taken from the global variable multiprocess_init_args).
+
+        Parameters
+        ----------
+        chunk_id: int
+            This processes's id.
+
+        Return
+        -------
+        lines: list
+            List of list of 3D positions (streamlines).
+        """
+        self._cpu_reload_data_for_new_process()
+        try:
+            streamlines, seeds = self._cpu_tracking(chunk_id)
+            return streamlines, seeds
+        except Exception as e:
+            logging.error("Operation _cpu_tracking_sub() failed.")
+            traceback.print_exception(*sys.exc_info(), file=sys.stderr)
+            raise e
+
+    def _cpu_tracking(self, chunk_id):
+        """
+        Tracks the n streamlines associates with current process (identified by
+        chunk_id). The number n is the total number of seeds / the number of
+        processes. If asked by user, may compress the streamlines and save the
+        seeds.
+
+        Parameters
+        ----------
+        chunk_id: int
+            This process ID.
+
+        Returns
+        -------
+        streamlines: list
+            The successful streamlines.
+        seeds: list
+            The list of seeds for each streamline, if self.save_seeds. Else, an
+            empty list.
+        """
+        streamlines = []
+        seeds = []
+
+        # Initialize the random number generator to cover multiprocessing,
+        # skip, which voxel to seed and the subvoxel random position
+        chunk_size = int(self.nbr_seeds / self.nbr_processes)
+        first_seed_of_chunk = chunk_id * chunk_size + self.skip
+        random_generator, indices = self.seed_generator.init_generator(
+            self.rng_seed, first_seed_of_chunk)
+        if chunk_id == self.nbr_processes - 1:
+            chunk_size += self.nbr_seeds % self.nbr_processes
+
+        # Getting streamlines
+        for s in range(chunk_size):
+            if s % self.printing_frequency == 0:
+                logging.info("Process {} (id {}): {} / {}"
+                             .format(chunk_id, os.getpid(), s, chunk_size))
+
+            seed = self.seed_generator.get_next_pos(
+                random_generator, indices, first_seed_of_chunk + s)
+
+            # Forward and backward tracking
+            line = self._get_multiple_lines_both_directions([seed])[0]
+
+            if line is not None:
+                streamline = np.array(line, dtype='float32')
+
+                if self.compression_th and self.compression_th > 0:
+                    # Compressing. Threshold is in mm. Verifying space.
+                    if self.space == Space.VOX:
+                        # Equivalent of sft.to_voxmm:
+                        streamline *= self.seed_generator.voxres
+                        compress_streamlines(streamline, self.compression_th)
+                        # Equivalent of sft.to_vox:
+                        streamline /= self.seed_generator.voxres
+                    else:
+                        compress_streamlines(streamline, self.compression_th)
+
+                streamlines.append(streamline)
+
+                if self.save_seeds:
+                    seeds.append(np.asarray(seed, dtype='float32'))
+
+        return streamlines, seeds
+        
+    def _gpu_simultanenous_tracking(self):
         """
         Creating all seeds at once and propagating all streamlines together.
         """
@@ -149,15 +289,8 @@ class DWIMLTracker(ScilpyTracker):
 
         return lines, seeds
 
-    def _get_line_both_directions(self, seed: np.ndarray):
-        # Only using our torch-based version. Skipping scilpy's single-version.
-        self._get_multiple_lines_both_directions([seed])
-
     def _get_multiple_lines_both_directions(self, n_seeds: List[np.ndarray]):
         """
-        Equivalent of super's() _get_line_both_directions() for multiple lines
-        tracking at the same time (meant to be used on GPU).
-
         Params
         ------
         n_seeds : List[np.ndarray]
@@ -275,3 +408,21 @@ class DWIMLTracker(ScilpyTracker):
             final_lines, final_tracking_info, self.mask)
 
         return final_lines
+
+    def _verify_stopping_criteria(self, invalid_direction_count, last_pos):
+
+        # Checking number of consecutive invalid directions
+        if invalid_direction_count > self.max_invalid_dirs:
+            return False
+
+        # Checking if out of bound
+        if not self.mask.is_coordinate_in_bound(
+                *last_pos, space=self.space, origin=self.origin):
+            return False
+
+        # Checking if out of mask
+        if self.mask.get_value_at_coordinate(
+                *last_pos, space=self.space, origin=self.origin) <= 0:
+            return False
+
+        return True

--- a/dwi_ml/tracking/tracking_mask.py
+++ b/dwi_ml/tracking/tracking_mask.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+from scilpy.image.datasets import DataVolume
+
+
+class TrackingMask:
+    def __init__(self, dim, data_volume: DataVolume = None):
+        # Required dim to check if out of bounds, even with no tracking mask
+        self.dim = dim
+
+        # Optional tracking mask
+        self.data_volume = data_volume
+        if data_volume is not None:
+            assert dim == data_volume.dim
+
+    def is_vox_corner_in_bound(self, x, y, z):
+        # Uses data_volume.is_coordinate_in_bound with space=VOX,
+        # origin=Corner.
+        i, j, k = np.floor((x, y, z))  # vox to idx
+        return (0 <= i < (self.dim[0]) and
+                0 <= j < (self.dim[1]) and
+                0 <= k < (self.dim[2]))

--- a/dwi_ml/tracking/tracking_mask.py
+++ b/dwi_ml/tracking/tracking_mask.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import numpy as np
 import torch
 
 from dwi_ml.data.processing.volume.interpolation import \
@@ -7,7 +6,7 @@ from dwi_ml.data.processing.volume.interpolation import \
 
 
 class TrackingMask:
-    def __init__(self, dim, data=None, interp: str = None):
+    def __init__(self, dim, data=None, interp: str = 'nearest'):
         # Required dim to check if out of bounds, even with no tracking mask
         self.higher_bound = torch.as_tensor(dim[0:3])
         self.lower_bound = torch.as_tensor([0, 0, 0])[None, :]
@@ -50,4 +49,4 @@ class TrackingMask:
     def is_in_mask(self, xyz):
         return torch.greater_equal(
             self.get_value_at_vox_corner_coordinate(xyz, 'nearest'),
-            torch.zeros(1, xyz.device))
+            torch.zeros(1, device=xyz.device))

--- a/dwi_ml/tracking/utils.py
+++ b/dwi_ml/tracking/utils.py
@@ -198,12 +198,12 @@ def prepare_tracking_mask(args, hdf_handle):
                        .format(args.tracking_mask_group, args.subj_id,
                                hdf_handle))
     tm_group = hdf_handle[args.subj_id][args.tracking_mask_group]
-    mask_data = np.array(tm_group['data'], dtype=np.float64)
+    mask_data = np.array(tm_group['data'], dtype=np.float64).squeeze()
     # mask_res = np.array(tm_group.attrs['voxres'], dtype=np.float32)
     affine = np.array(tm_group.attrs['affine'], dtype=np.float32)
     ref = nib.Nifti1Image(mask_data, affine)
 
-    mask = TrackingMask(mask_data, args.mask_interp)
+    mask = TrackingMask(mask_data.shape, mask_data, args.mask_interp)
 
     return mask, ref
 

--- a/dwi_ml/tracking/utils.py
+++ b/dwi_ml/tracking/utils.py
@@ -8,11 +8,11 @@ import numpy as np
 from dipy.io.streamline import save_tractogram
 
 from scilpy.io.utils import add_processes_arg
-from scilpy.image.datasets import DataVolume
 from scilpy.tracking.seed import SeedGenerator
 
 from dwi_ml.data.dataset.multi_subject_containers import MultiSubjectDataset
 from dwi_ml.experiment_utils.timer import Timer
+from dwi_ml.tracking.tracking_mask import TrackingMask
 
 
 def add_mandatory_options_tracking(p):
@@ -199,11 +199,11 @@ def prepare_tracking_mask(args, hdf_handle):
                                hdf_handle))
     tm_group = hdf_handle[args.subj_id][args.tracking_mask_group]
     mask_data = np.array(tm_group['data'], dtype=np.float64)
-    mask_res = np.array(tm_group.attrs['voxres'], dtype=np.float32)
+    # mask_res = np.array(tm_group.attrs['voxres'], dtype=np.float32)
     affine = np.array(tm_group.attrs['affine'], dtype=np.float32)
     ref = nib.Nifti1Image(mask_data, affine)
 
-    mask = DataVolume(mask_data, mask_res, args.mask_interp)
+    mask = TrackingMask(mask_data, args.mask_interp)
 
     return mask, ref
 

--- a/dwi_ml/tracking/utils.py
+++ b/dwi_ml/tracking/utils.py
@@ -35,8 +35,6 @@ def add_mandatory_options_tracking(p):
                    help='Tractogram output file (must be .trk or .tck).')
     p.add_argument('seeding_mask_group',
                    help="Seeding mask's volume group in the hdf5.")
-    p.add_argument('tracking_mask_group',
-                   help="Tracking mask's volume group in the hdf5.")
     p.add_argument('input_group',
                    help="Model's input's volume group in the hdf5.")
     p.add_argument('--subset', default='testing',
@@ -66,6 +64,8 @@ def add_tracking_options(p):
                          metavar='M',
                          help='Maximum length of a streamline in mm. '
                               '[%(default)s]')
+    track_g.add_argument('--tracking_mask_group',
+                         help="Tracking mask's volume group in the hdf5.")
 
     # Additional tracking options compared to scil_compute_local_tracking:
     track_g.add_argument('--theta', metavar='t', type=float,
@@ -165,6 +165,7 @@ def prepare_seed_generator(parser, args, hdf_handle):
     seed_data = np.array(seeding_group['data'], dtype=np.float32)
     seed_res = np.array(seeding_group.attrs['voxres'], dtype=np.float32)
     affine = np.array(seeding_group.attrs['affine'], dtype=np.float32)
+    ref = nib.Nifti1Image(seed_data, affine)
 
     seed_generator = SeedGenerator(seed_data, seed_res, space=Space.VOX,
                                    origin=Origin('corner'))
@@ -184,7 +185,7 @@ def prepare_seed_generator(parser, args, hdf_handle):
 
     seed_header = nib.Nifti1Image(seed_data, affine).header
 
-    return seed_generator, nbr_seeds, seed_header
+    return seed_generator, nbr_seeds, seed_header, ref
 
 
 def prepare_tracking_mask(args, hdf_handle):

--- a/scripts_python/l2t_track_from_model.py
+++ b/scripts_python/l2t_track_from_model.py
@@ -27,6 +27,7 @@ from dwi_ml.experiment_utils.timer import Timer
 from dwi_ml.models.projects.learn2track_model import Learn2TrackModel
 from dwi_ml.tracking.projects.learn2track_propagator import RecurrentPropagator
 from dwi_ml.tracking.tracker import DWIMLTracker
+from dwi_ml.tracking.tracking_mask import TrackingMask
 from dwi_ml.tracking.utils import (add_mandatory_options_tracking,
                                    add_tracking_options,
                                    prepare_dataset_one_subj,
@@ -69,15 +70,21 @@ def prepare_tracker(parser, args, device, min_nbr_pts, max_nbr_pts,
                newline=True, color='green'):
         logging.info("Loading seeding mask + preparing seed generator.")
         # Vox space, corner origin
-        seed_generator, nbr_seeds, seeding_mask_header = \
+        seed_generator, nbr_seeds, seeding_mask_header, ref = \
             prepare_seed_generator(parser, args, hdf_handle)
-
-        logging.info("Loading tracking mask.")
-        tracking_mask, ref = prepare_tracking_mask(args, hdf_handle)
-
-        # Comparing tracking and seeding masks
-        is_header_compatible(ref, seeding_mask_header)
         res = seeding_mask_header['pixdim'][0:3]
+        dim = seeding_mask_header['dim'][0:3]
+
+        if args.tracking_mask_group is not None:
+            logging.info("Loading tracking mask.")
+            data_volume, ref2 = prepare_tracking_mask(args, hdf_handle)
+
+            # Comparing tracking and seeding masks
+            is_header_compatible(ref2, seeding_mask_header)
+
+            tracking_mask = TrackingMask(dim, data_volume)
+        else:
+            tracking_mask = TrackingMask(dim)
 
         logging.info("Loading subject's data.")
         subset, subj_idx = prepare_dataset_one_subj(args)

--- a/scripts_python/l2t_track_from_model.py
+++ b/scripts_python/l2t_track_from_model.py
@@ -73,16 +73,14 @@ def prepare_tracker(parser, args, device, min_nbr_pts, max_nbr_pts,
         seed_generator, nbr_seeds, seeding_mask_header, ref = \
             prepare_seed_generator(parser, args, hdf_handle)
         res = seeding_mask_header['pixdim'][0:3]
-        dim = seeding_mask_header['dim'][0:3]
+        dim = ref.shape
 
         if args.tracking_mask_group is not None:
             logging.info("Loading tracking mask.")
-            data_volume, ref2 = prepare_tracking_mask(args, hdf_handle)
+            tracking_mask, ref2 = prepare_tracking_mask(args, hdf_handle)
 
             # Comparing tracking and seeding masks
             is_header_compatible(ref2, seeding_mask_header)
-
-            tracking_mask = TrackingMask(dim, data_volume)
         else:
             tracking_mask = TrackingMask(dim)
 

--- a/scripts_python/tests/test_all_steps_learn2track.py
+++ b/scripts_python/tests/test_all_steps_learn2track.py
@@ -85,9 +85,9 @@ def test_execution_training_tracking(script_runner, experiments_path):
     # subjectX from training set.
     ret = script_runner.run(
         'l2t_track_from_model.py', whole_experiment_path, hdf5_file, subj_id,
-        out_tractogram, seeding_mask_group, tracking_mask_group, input_group,
+        out_tractogram, seeding_mask_group, input_group,
         '--algo', 'det', '--nt', '2', '--rng_seed', '0', '--min_length', '0',
-        '--subset', 'training')
+        '--subset', 'training', '--tracking_mask_group', tracking_mask_group)
 
     assert ret.success
 
@@ -97,9 +97,10 @@ def test_execution_training_tracking(script_runner, experiments_path):
         out_tractogram = os.path.join(experiments_path, 'test_tractogram2.trk')
         ret = script_runner.run(
             'l2t_track_from_model.py', whole_experiment_path, hdf5_file,
-            subj_id, out_tractogram, seeding_mask_group, tracking_mask_group,
+            subj_id, out_tractogram, seeding_mask_group,
             input_group, '--algo', 'det', '--nt', '20', '--rng_seed', '0',
             '--min_length', '0', '--subset', 'training',
+            '--tracking_mask_group', tracking_mask_group,
             # Additional params compared to CPU:
             '--use_gpu', '--simultaneous_tracking', '3')
 

--- a/scripts_python/tests/test_all_steps_tto.py
+++ b/scripts_python/tests/test_all_steps_tto.py
@@ -95,9 +95,11 @@ def test_execution(script_runner, experiments_path):
 
     ret = script_runner.run(
         'tto_track_from_model.py', whole_experiment_path, hdf5_file, subj_id,
-        out_tractogram, seeding_mask_group, tracking_mask_group, input_group,
+        out_tractogram, seeding_mask_group, input_group,
         '--algo', 'det', '--nt', '2', '--rng_seed', '0',
-        '--min_length', '0', '--subset', 'training', '--logging', 'DEBUG')
+        '--min_length', '0', '--subset', 'training', '--logging', 'DEBUG',
+        '--max_length', str(MAX_LEN * 0.5), '--step', '0.5',
+        '--tracking_mask_group', tracking_mask_group)
 
     assert ret.success
 

--- a/scripts_python/tests/test_all_steps_ttst.py
+++ b/scripts_python/tests/test_all_steps_ttst.py
@@ -92,9 +92,11 @@ def test_execution(script_runner, experiments_path):
 
     ret = script_runner.run(
         'ttst_track_from_model.py', whole_experiment_path, hdf5_file, subj_id,
-        out_tractogram, seeding_mask_group, tracking_mask_group, input_group,
+        out_tractogram, seeding_mask_group, input_group,
         '--algo', 'det', '--nt', '2', '--rng_seed', '0',
-        '--min_length', '0', '--subset', 'training')
+        '--min_length', '0', '--subset', 'training',
+        '--max_length', str(MAX_LEN * 0.5), '--step', '0.5',
+        '--tracking_mask_group', tracking_mask_group)
     assert ret.success
 
     logging.info("************ TESTING VISUALIZE WEIGHTS ************")

--- a/scripts_python/tto_track_from_model.py
+++ b/scripts_python/tto_track_from_model.py
@@ -79,12 +79,10 @@ def prepare_tracker(parser, args, device,
 
         if args.tracking_mask_group is not None:
             logging.info("Loading tracking mask.")
-            data_volume, ref2 = prepare_tracking_mask(args, hdf_handle)
+            tracking_mask, ref2 = prepare_tracking_mask(args, hdf_handle)
 
             # Comparing tracking and seeding masks
             is_header_compatible(ref2, seeding_mask_header)
-
-            tracking_mask = TrackingMask(dim, data_volume)
         else:
             tracking_mask = TrackingMask(dim)
 

--- a/scripts_python/ttst_track_from_model.py
+++ b/scripts_python/ttst_track_from_model.py
@@ -75,16 +75,14 @@ def prepare_tracker(parser, args, device,
         seed_generator, nbr_seeds, seeding_mask_header, ref = \
             prepare_seed_generator(parser, args, hdf_handle)
         res = seeding_mask_header['pixdim'][0:3]
-        dim = seeding_mask_header['dim'][0:3]
+        dim = ref.shape
 
         if args.tracking_mask_group is not None:
             logging.info("Loading tracking mask.")
-            data_volume, ref2 = prepare_tracking_mask(args, hdf_handle)
+            tracking_mask, ref2 = prepare_tracking_mask(args, hdf_handle)
 
             # Comparing tracking and seeding masks
             is_header_compatible(ref2, seeding_mask_header)
-
-            tracking_mask = TrackingMask(dim, data_volume)
         else:
             tracking_mask = TrackingMask(dim)
 

--- a/scripts_python/ttst_track_from_model.py
+++ b/scripts_python/ttst_track_from_model.py
@@ -29,6 +29,7 @@ from dwi_ml.models.projects.transforming_tractography import TransformerSrcAndTg
 from dwi_ml.tracking.projects.transformer_propagator import \
     TransformerPropagator
 from dwi_ml.tracking.tracker import DWIMLTracker
+from dwi_ml.tracking.tracking_mask import TrackingMask
 from dwi_ml.tracking.utils import (add_mandatory_options_tracking,
                                    add_tracking_options,
                                    prepare_seed_generator,
@@ -71,15 +72,21 @@ def prepare_tracker(parser, args, device,
     with Timer("\n\nLoading data and preparing tracker...",
                newline=True, color='green'):
         logging.info("Loading seeding mask + preparing seed generator.")
-        seed_generator, nbr_seeds, seeding_mask_header = \
+        seed_generator, nbr_seeds, seeding_mask_header, ref = \
             prepare_seed_generator(parser, args, hdf_handle)
-
-        logging.info("Loading tracking mask.")
-        tracking_mask, ref = prepare_tracking_mask(args, hdf_handle)
-
-        # Comparing tracking and seeding masks
-        is_header_compatible(ref, seeding_mask_header)
         res = seeding_mask_header['pixdim'][0:3]
+        dim = seeding_mask_header['dim'][0:3]
+
+        if args.tracking_mask_group is not None:
+            logging.info("Loading tracking mask.")
+            data_volume, ref2 = prepare_tracking_mask(args, hdf_handle)
+
+            # Comparing tracking and seeding masks
+            is_header_compatible(ref2, seeding_mask_header)
+
+            tracking_mask = TrackingMask(dim, data_volume)
+        else:
+            tracking_mask = TrackingMask(dim)
 
         logging.info("Loading subject's data.")
         subset, subj_idx = prepare_dataset_one_subj(args)

--- a/scripts_python/ttst_track_from_model.py
+++ b/scripts_python/ttst_track_from_model.py
@@ -13,7 +13,6 @@ import dipy.core.geometry as gm
 from dipy.io.utils import is_header_compatible
 import h5py
 import nibabel as nib
-import torch
 
 from scilpy.io.utils import (add_sphere_arg,
                              assert_inputs_exist, assert_outputs_exist,
@@ -26,9 +25,8 @@ from dwi_ml.data.dataset.utils import add_dataset_args
 from dwi_ml.experiment_utils.prints import format_dict_to_str, add_logging_arg
 from dwi_ml.experiment_utils.timer import Timer
 from dwi_ml.models.projects.transforming_tractography import TransformerSrcAndTgtModel
-from dwi_ml.tracking.projects.transformer_propagator import \
-    TransformerPropagator
-from dwi_ml.tracking.tracker import DWIMLTracker
+from dwi_ml.tracking.projects.transformer_tracker import \
+    TransformerTracker
 from dwi_ml.tracking.tracking_mask import TrackingMask
 from dwi_ml.tracking.utils import (add_mandatory_options_tracking,
                                    add_tracking_options,
@@ -60,8 +58,7 @@ def build_argparser():
     return p
 
 
-def prepare_tracker(parser, args, device,
-                    min_nbr_pts, max_nbr_pts, max_invalid_dirs):
+def prepare_tracker(parser, args, min_nbr_pts, max_nbr_pts, max_invalid_dirs):
     hdf_handle = h5py.File(args.hdf5_file, 'r')
 
     sub_logger_level = args.logging.upper()
@@ -95,21 +92,21 @@ def prepare_tracker(parser, args, device,
         logging.info("* Formatted model: " +
                      format_dict_to_str(model.params_for_checkpoint))
 
-        logging.debug("Instantiating propagator.")
         theta = gm.math.radians(args.theta)
         step_size_vox, normalize_directions = prepare_step_size_vox(
             args.step_size, res)
-        propagator = TransformerPropagator(
-            dataset=subset, subj_idx=subj_idx, model=model,
-            input_volume_group=args.input_group, step_size=step_size_vox,
-            algo=args.algo, theta=theta, device=device)
 
         logging.debug("Instantiating tracker.")
-        tracker = DWIMLTracker(
-            propagator, tracking_mask, seed_generator, nbr_seeds, min_nbr_pts,
-            max_nbr_pts, max_invalid_dirs, args.compress, args.nbr_processes,
-            args.save_seeds, args.rng_seed, args.track_forward_only,
-            use_gpu=args.use_gpu,
+        tracker = TransformerTracker(
+            input_volume_group=args.input_group,
+            dataset=subset, subj_idx=subj_idx, model=model, mask=tracking_mask,
+            seed_generator=seed_generator, nbr_seeds=nbr_seeds,
+            min_nbr_pts=min_nbr_pts, max_nbr_pts=max_nbr_pts,
+            max_invalid_dirs=max_invalid_dirs, compression_th=args.compress,
+            nbr_processes=args.nbr_processes, save_seeds=args.save_seeds,
+            rng_seed=args.rng_seed, track_forward_only=args.track_forward_only,
+            step_size=step_size_vox, algo=args.algo, theta=theta,
+            normalize_directions=normalize_directions, use_gpu=args.use_gpu,
             simultanenous_tracking=args.simultaneous_tracking,
             log_level=args.logging)
 
@@ -144,16 +141,7 @@ def main():
     min_nbr_pts = int(args.min_length / args.step_size)
     max_invalid_dirs = int(math.ceil(args.max_invalid_len / args.step_size)) - 1
 
-    device = torch.device('cpu')
-    if args.use_gpu:
-        if args.nbr_processes > 1:
-            logging.warning("Number of processes was set to {} but you "
-                            "are using GPU. Parameter ignored."
-                            .format(args.nbr_processes))
-        if torch.cuda.is_available():
-            device = torch.device('cuda')
-
-    tracker, ref = prepare_tracker(parser, args, device,
+    tracker, ref = prepare_tracker(parser, args,
                                    min_nbr_pts, max_nbr_pts, max_invalid_dirs)
 
     # ----- Track


### PR DESCRIPTION
Too difficult to use child classes of scilpy's tracker and propagators: they use numpy, we use torch.

Also, we merge the tracker and propagator: much easier to deal with memory stuff.