### PR TITLE
Try to migrate to yaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,11 +18,6 @@ nested_lookup==0.2.25
 nose==1.3.*
 
 
-#sphinx_rtd_theme>=0.4.* ---> Difficult to use with latest versions
-#sphinx-book-theme ---> not working?
-sphinx > 3.0
-
-
 ## Necessary but should be installed with scilpy (Last check: 09/2023):
 future==0.18.*
 h5py==3.7.*   # h5py must absolutely be >2.4: that's when it became thread-safe

--- a/source/.readthedocs.yaml
+++ b/source/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: source/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+   - requirements: source/docs_requirements.txt

--- a/source/README_how_to_setup_rtd.txt
+++ b/source/README_how_to_setup_rtd.txt
@@ -1,0 +1,12 @@
+
+To the developpers of dwi_ml:
+
+The make the read the doc into a webpage:
+
+Go to https://readthedocs.org/projects/dwi-ml/
+
+Currently, the account is managed by Emmanuelle Renauld
+(note to self: through Github's account).
+
+See here for explanation on the yaml file:
+https://blog.readthedocs.com/migrate-configuration-v2/

--- a/source/docs_requirements.txt
+++ b/source/docs_requirements.txt
@@ -1,0 +1,4 @@
+
+#sphinx_rtd_theme>=0.4.* ---> Difficult to use with latest versions
+#sphinx-book-theme ---> not working?
+sphinx > 3.0


### PR DESCRIPTION
Doc management is deprecated. Doc not building since one month.
Trying to set the migration details. Need to merge in order to see if worked.

![image](https://github.com/scil-vital/dwi_ml/assets/4967417/46143d1b-24bd-4c42-9e82-8002e5cb99cb)
