### PR TITLE
Removing unnecessary params model_uses_forward and loss_uses_forward

### DIFF
--- a/dwi_ml/models/main_models.py
+++ b/dwi_ml/models/main_models.py
@@ -69,10 +69,6 @@ class MainModelAbstract(torch.nn.Module):
 
         self.device = None
 
-        # To tell our trainer what to send to the forward / loss methods.
-        self.forward_uses_streamlines = False
-        self.loss_uses_streamlines = False
-        
         # To tell our batch loader how to resample streamlines during training
         # (should also be the step size during tractography).
         if step_size and compress_lines:
@@ -205,10 +201,10 @@ class MainModelAbstract(torch.nn.Module):
 
         return model_state
 
-    def forward(self, *inputs, **kw):
+    def forward(self, inputs, streamlines):
         raise NotImplementedError
 
-    def compute_loss(self, *model_outputs, **kw):
+    def compute_loss(self, model_outputs, target_streamlines):
         raise NotImplementedError
 
 
@@ -369,10 +365,6 @@ class ModelWithPreviousDirections(MainModelAbstract):
             self.prev_dirs_embedded_size = None
             self.prev_dirs_embedding = None
 
-        # To tell our trainer what to send to the forward / loss methods.
-        if nb_previous_dirs > 0:
-            self.forward_uses_streamlines = True
-
     @staticmethod
     def add_args_model_with_pd(p):
         # CNN embedding makes no sense for previous dir
@@ -411,7 +403,7 @@ class ModelWithPreviousDirections(MainModelAbstract):
         })
         return p
 
-    def forward(self, inputs, target_streamlines: List[torch.tensor], **kw):
+    def forward(self, inputs, target_streamlines: List[torch.tensor]):
         """
         Params
         ------
@@ -709,9 +701,6 @@ class ModelWithDirectionGetter(MainModelAbstract):
         if self.dg_key not in keys_to_direction_getters.keys():
             raise ValueError("Direction getter choice not understood: {}"
                              .format(self.positional_encoding_key))
-
-        # To tell our trainer what to send to the forward / loss methods.
-        self.loss_uses_streamlines = True
 
     def set_context(self, context):
         assert context in ['training', 'tracking', 'visu']

--- a/dwi_ml/models/projects/learn2track_model.py
+++ b/dwi_ml/models/projects/learn2track_model.py
@@ -188,15 +188,6 @@ class Learn2TrackModel(ModelWithPreviousDirections, ModelWithDirectionGetter,
         # 4. Direction getter:
         self.instantiate_direction_getter(self.rnn_model.output_size)
 
-        # If multiple inheritance goes well, these params should be set
-        # correctly
-        if nb_previous_dirs > 0:
-            assert self.forward_uses_streamlines
-        assert self.loss_uses_streamlines
-
-        if self.start_from_copy_prev:
-            self.forward_uses_streamlines = True
-
     def set_context(self, context):
         assert context in ['training', 'validation', 'tracking', 'visu',
                            'preparing_backward']

--- a/dwi_ml/models/projects/transformer_models.py
+++ b/dwi_ml/models/projects/transformer_models.py
@@ -224,8 +224,6 @@ class AbstractTransformerModel(ModelWithNeighborhood, ModelWithDirectionGetter,
         # the nb of features.
         self.instantiate_direction_getter(self.d_model)
 
-        assert self.loss_uses_streamlines
-
     @property
     def d_model(self):
         raise NotImplementedError
@@ -367,9 +365,11 @@ class AbstractTransformerModel(ModelWithNeighborhood, ModelWithDirectionGetter,
             raise ValueError("Please set context before usage.")
 
         # ----------- Checks
-        if self.forward_uses_streamlines:
-            # Reminder. In all cases, len(each input) == len(each streamline).
-            # Correct interpolation and management of points should be done before.
+        if input_streamlines is not None:
+            # If streamlines are necessary (depending on child class):
+            # In all cases, len(each input) == len(each streamline).
+            # Correct interpolation and management of points should be done
+            # before.
             assert np.all([len(i) == len(s) for i, s in
                            zip(inputs, input_streamlines)])
 
@@ -617,8 +617,6 @@ class AbstractTransformerModelWithTarget(AbstractTransformerModel):
         cls_t = keys_to_embeddings[self.target_embedding_key]
         self.embedding_layer_t = cls_t(self.target_features,
                                        self.target_embedded_size)
-
-        self.forward_uses_streamlines = True
 
     @property
     def params_for_checkpoint(self):

--- a/dwi_ml/tracking/tracker.py
+++ b/dwi_ml/tracking/tracker.py
@@ -494,10 +494,7 @@ class DWIMLAbstractTracker:
 
     def _call_model_forward(self, inputs, lines):
         with self.grad_context:
-            if self.model.forward_uses_streamlines:
-                model_outputs = self.model(inputs, lines)
-            else:
-                model_outputs = self.model(inputs)
+            model_outputs = self.model(inputs, lines)
         return model_outputs
 
     def update_memory_after_removing_lines(self, can_continue: np.ndarray,

--- a/dwi_ml/training/trainers.py
+++ b/dwi_ml/training/trainers.py
@@ -1092,33 +1092,22 @@ class DWIMLTrainerOneInput(DWIMLAbstractTrainer):
         batch_inputs = self.batch_loader.load_batch_inputs(
             streamlines_f, ids_per_subj)
 
-        # Possibly add noise to inputs here.
         logger.debug('*** Computing forward propagation')
-        if self.model.forward_uses_streamlines:
-            # Now possibly add noise to streamlines (training / valid)
-            streamlines_f = self.batch_loader.add_noise_streamlines_forward(
-                streamlines_f, self.device)
-
-            # Possibly computing directions twice (during forward and loss)
-            # but ok, shouldn't be too heavy. Easier to deal with multiple
-            # projects' requirements by sending whole streamlines rather
-            # than only directions.
-            model_outputs = self.model(batch_inputs, streamlines_f)
-            del streamlines_f
-        else:
-            del streamlines_f
-            model_outputs = self.model(batch_inputs)
+        # todo Possibly add noise to inputs here. Not ready
+        # Now add noise to streamlines for the forward pass
+        # (batch loader will do it depending on training / valid)
+        streamlines_f = self.batch_loader.add_noise_streamlines_forward(
+            streamlines_f, self.device)
+        model_outputs = self.model(batch_inputs, streamlines_f)
+        del streamlines_f
 
         logger.debug('*** Computing loss')
-        if self.model.loss_uses_streamlines:
-            targets = self.batch_loader.add_noise_streamlines_loss(
-                targets, self.device)
-
-            results = self.model.compute_loss(model_outputs, targets,
-                                              average_results=True)
-        else:
-            results = self.model.compute_loss(model_outputs,
-                                              average_results=True)
+        # Add noise to targets.
+        # (batch loader will do it depending on training / valid)
+        targets = self.batch_loader.add_noise_streamlines_loss(targets,
+                                                               self.device)
+        results = self.model.compute_loss(model_outputs, targets,
+                                          average_results=True)
 
         if self.use_gpu:
             log_gpu_memory_usage(logger)

--- a/dwi_ml/training/with_generation/trainer.py
+++ b/dwi_ml/training/with_generation/trainer.py
@@ -364,10 +364,7 @@ class DWIMLTrainerForTrackingOneInput(DWIMLTrainerOneInput):
             batch_inputs = self.batch_loader.load_batch_inputs(
                 n_last_pos, ids_per_subj)
 
-            if self.model.forward_uses_streamlines:
-                model_outputs = self.model(batch_inputs, n_last_pos)
-            else:
-                model_outputs = self.model(batch_inputs)
+            model_outputs = self.model(batch_inputs, n_last_pos)
 
             next_dirs = self.model.get_tracking_directions(
                 model_outputs, algo='det', eos_stopping_thresh=0.5)


### PR DESCRIPTION
Now always sending streamlines both in forward and in loss. Much simpler, not heavier. User can decide to ignore.