### PR TITLE
Update dependencies

### DIFF
--- a/dwi_ml/data/processing/streamlines/post_processing.py
+++ b/dwi_ml/data/processing/streamlines/post_processing.py
@@ -8,7 +8,7 @@ from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from scilpy.tractanalysis.tools import \
+from scilpy.tractanalysis.connectivity_segmentation import \
     extract_longest_segments_from_profile as segmenting_func
 from scilpy.tractograms.uncompress import uncompress
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+# Minimal build configuration at detailed here:
+# https://github.com/pypa/pip/issues/11457
+
+[build-system]
+requires = [
+    "setuptools >= 64"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 # -------
 requests==2.28.*
 dipy==1.9.*
--e git+https://github.com/levje/scilpy@update_scilpy#egg=scilpy
+-e git+https://github.com/scilus/scilpy@24435143c507ca018dd7edf3447fd18004c62077#egg=scilpy
 
 # -------
 # Other important dependencies
@@ -28,9 +28,9 @@ pynvml>=11.5.0
 # Necessary but should be installed with scilpy (Last check: 04/2024):
 # -------
 future==0.18.*
-h5py==3.7.*   # h5py must absolutely be >2.4: that's when it became thread-safe
+h5py==3.10.*   # h5py must absolutely be >2.4: that's when it became thread-safe
 matplotlib==3.6.*   # Hint: If matplotlib fails, you may try to install pyQt5.
 nibabel==5.2.*
-numpy==1.23.*
-scipy==1.9.*
+numpy==1.25.*
+scipy==1.11.*
 scikit-image==0.22.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 # -------
 requests==2.28.*
 dipy==1.9.*
-scilpy==2.0.2
+-e git+https://github.com/levje/scilpy@update_scilpy#egg=scilpy
 
 # -------
 # Other important dependencies

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ opts = dict(name=NAME,
             version=VERSION,
             packages=find_packages(),
             python_requires=PYTHON_VERSION,
-            setup_requires=['numpy'],
             install_requires=external_dependencies,
             entry_points={
                 'console_scripts': ["{}=scripts_python.{}:main".format(


### PR DESCRIPTION
## Description
The main objective of this PR is to remove the use of the branch "for_beluga_scilpy2" which uses a version of scilpy that can't be built properly. I just got another PR merged (https://github.com/scilus/scilpy/pull/1048) into scilpy's master which fixes some issues regarding its problematic building process. Also, scilpy's master currently has the updated packages from the "for_beluga_scilpy2" branch.

With that fix, I also found that dwi_ml doesn't have a pyproject.toml which means that when building dwi_ml, the legacy building process invoking the `pythons setup.py develop` is called. Since that behavior will be enforced from pip 25.0 and onwards, we will need to make sure that dwi_ml follows that convention. I added that pyproject.toml with the minimal configuration needed for the project.  

If you prefer to wait for an official scilpy release in december, we want wait before merging this. But we could also just push another update whenever there's something released and more stable.