### PR TITLE
Update to scilpy 2.2.0 rc1

### DIFF
--- a/dwi_ml/data/processing/streamlines/post_processing.py
+++ b/dwi_ml/data/processing/streamlines/post_processing.py
@@ -7,10 +7,9 @@ import torch
 from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-
-from scilpy.tractanalysis.tools import \
+from scilpy.tractanalysis.connectivity_segmentation import \
     extract_longest_segments_from_profile as segmenting_func
-from scilpy.tractograms.uncompress import uncompress
+from scilpy.tractograms.uncompress import streamlines_to_voxel_coordinates
 
 # We could try using nan instead of zeros for non-existing previous dirs...
 DEFAULT_UNEXISTING_VAL = torch.zeros((1, 3), dtype=torch.float32)
@@ -349,7 +348,8 @@ def compute_triu_connectivity_from_labels(streamlines, data_labels,
     end_labels = []
 
     if use_scilpy:
-        indices, points_to_idx = uncompress(streamlines, return_mapping=True)
+        indices, points_to_idx = streamlines_to_voxel_coordinates(
+            streamlines, return_mapping=True)
 
         for strl_vox_indices in indices:
             segments_info = segmenting_func(strl_vox_indices, data_labels)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@
 #    which installs a version >2.28. Adding request version explicitely.
 # -------
 requests==2.28.*
-dipy==1.9.*
-scilpy==2.0.2
+dipy==1.10.*
+#scilpy==2.2.0-rc1 - to be installed manually
 
 # -------
 # Other important dependencies
@@ -28,9 +28,9 @@ pynvml>=11.5.0
 # Necessary but should be installed with scilpy (Last check: 04/2024):
 # -------
 future==0.18.*
-h5py==3.7.*   # h5py must absolutely be >2.4: that's when it became thread-safe
+h5py==3.10.*
 matplotlib==3.6.*   # Hint: If matplotlib fails, you may try to install pyQt5.
 nibabel==5.2.*
-numpy==1.23.*
-scipy==1.9.*
+numpy==1.25.*
+scipy==1.11.*
 scikit-image==0.22.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 # -------
 requests==2.28.*
 dipy==1.10.*
-#scilpy==2.2.0-rc1 - to be installed manually
+scilpy @ git+https://github.com/scilus/scilpy@2.2.0-rc1
 
 # -------
 # Other important dependencies


### PR DESCRIPTION
Installation as it was not possible on beluga anymore. All my branches "for_beluga" have been deleted.


Starting anew. Currently, it is possible to install version 2.2.0-rc1 on beluga, so starting from there. 

That's a ~2 years improvement on scilpy's version. Unit tests passing, I will try to do a test-retest with my stuff see if results are roughly the same.