### PR TITLE
Remove warning for non-positional argument

### DIFF
--- a/dwi_ml/data/dataset/streamline_containers.py
+++ b/dwi_ml/data/dataset/streamline_containers.py
@@ -312,7 +312,7 @@ class SFTDataAbstract(object):
         streamlines, dps = self._get_streamlines_as_list(streamline_ids)
 
         sft = StatefulTractogram(streamlines, self.space_attributes,
-                                 self.space, self.origin,
+                                 self.space, origin=self.origin,
                                  data_per_streamline=dps)
 
         return sft

--- a/dwi_ml/models/direction_getter_models.py
+++ b/dwi_ml/models/direction_getter_models.py
@@ -601,7 +601,7 @@ class AbstractSphereClassificationDG(AbstractDirectionGetterModel):
 
         # Classes
         self.sphere_name = sphere
-        sphere = dipy.data.get_sphere(sphere)
+        sphere = dipy.data.get_sphere(name=sphere)
         self.torch_sphere = TorchSphere(sphere)
         self.output_size = sphere.vertices.shape[0]   # nb_classes
 

--- a/dwi_ml/models/projects/transformer_models.py
+++ b/dwi_ml/models/projects/transformer_models.py
@@ -657,7 +657,7 @@ class AbstractTransformerModelWithTarget(AbstractTransformerModel):
             self.token_sphere = None
             self.target_features = 4
         else:
-            dipy_sphere = get_sphere(sos_token_type)
+            dipy_sphere = get_sphere(name=sos_token_type)
             self.token_sphere = TorchSphere(dipy_sphere)
             # nb classes = nb_vertices + SOS
             self.target_features = len(self.token_sphere.vertices) + 1

--- a/dwi_ml/testing/visu_loss.py
+++ b/dwi_ml/testing/visu_loss.py
@@ -292,7 +292,8 @@ def _create_colored_displacement(out_dirs, sft, model):
         'color_y': color_y,
         'color_z': color_z
     }
-    sft = sft.from_sft(out_streamlines, sft, data_per_point)
+    sft = sft.from_sft(out_streamlines, sft,
+                       data_per_point=data_per_point)
 
     return sft
 

--- a/dwi_ml/unit_tests/test_directionGetter_losses.py
+++ b/dwi_ml/unit_tests/test_directionGetter_losses.py
@@ -195,7 +195,7 @@ def test_sphere_classification_loss():
     logging.debug('Testing sphere classification loss')
 
     model = SphereClassificationDG(input_size=1)
-    sphere = get_sphere('symmetric724')
+    sphere = get_sphere(name='symmetric724')
 
     logging.debug("  - Neg log likelihood, expecting -ln(softmax).")
 

--- a/dwi_ml/unit_tests/test_submethods_eos_sos_and_class.py
+++ b/dwi_ml/unit_tests/test_submethods_eos_sos_and_class.py
@@ -28,7 +28,7 @@ def test_zeros():
 
 
 def test_classes(plot_sphere=False):
-    sphere = get_sphere('repulsion100')  # Sphere
+    sphere = get_sphere(name='repulsion100')  # Sphere
     torch_sphere = TorchSphere(sphere)
     idx_sos = 100
     idx_eos = 101


### PR DESCRIPTION
There were warnings when running with latest version (as of last week):

`Pass ['name'] as keyword args. From version 2.0.0 passing these as positional arguments will result in an error.`

Not sure version 2.0.0 of what, but anyway with this, tests go from 35 warnings to 13.