### PR TITLE
Investigating low tracking speed in Transformers

### DIFF
--- a/src/dwi_ml/general/experiment_utils/memory.py
+++ b/src/dwi_ml/general/experiment_utils/memory.py
@@ -14,7 +14,7 @@ def torch_reset_peaks_memory():
         torch.cuda.reset_peak_memory_stats()
 
 
-def log_gpu_general_info(logger_info=None, context: str = None):
+def log_gpu_general_info(logger_info=None, context: str = ""):
     """
     Prints general info. Available GPU, used by other processes, etc.
     Intended to be used at the start of the experiment.
@@ -57,7 +57,7 @@ def log_gpu_general_info(logger_info=None, context: str = None):
             logger_info.info(msg)
 
 
-def log_gpu_currently_allocated(logger_debug=None, context: str = None):
+def log_gpu_currently_allocated(logger_debug=None, context: str = ""):
     """
     Prints currently allocated GPU memory.
 
@@ -89,7 +89,7 @@ def log_gpu_currently_allocated(logger_debug=None, context: str = None):
             logger_debug.debug(msg)
 
 
-def log_gpu_max_allocated(logger_debug=None, context: str = None):
+def log_gpu_max_allocated(logger_debug=None, context: str = ""):
     if torch.cuda.is_available():
         msg = ("GPU: {}\n"
                "  - max memory: {:>6.3f}GB"
@@ -133,7 +133,7 @@ def log_currently_used_cpu(logger_debug=None, context: str = "", no_print=False)
     return system_memory.used, system_memory.percent
 
 
-def log_gpu_per_tensor(logger_debug=None, context: str = None):
+def log_gpu_per_tensor(logger_debug=None, context: str = ""):
     """
     Prints currently alive Tensors and Variables
     This is extensive and intended for debugging.

--- a/src/dwi_ml/general/tracking/propagation.py
+++ b/src/dwi_ml/general/tracking/propagation.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+
+"""
+About this file:
+
+The propagation is separated from the tracker, because this function can
+also be used by the trainer, inside the Generation-Validation [GV] phase.
+"""
 import logging
 from typing import Callable, List
 
@@ -6,6 +13,7 @@ import numpy as np
 import torch
 from torch import Tensor
 
+from dwi_ml.general.experiment_utils.memory import log_gpu_max_allocated
 from dwi_ml.general.tracking.tracking_mask import TrackingMask
 
 logger = logging.getLogger('tracker_logger')
@@ -40,6 +48,11 @@ def propagate_multiple_lines(
     max_nbr_pts: int
     append_last_point: bool
     normalize_directions: bool
+
+    Returns
+    -------
+    final_lines: List[Tensor]
+        The completed streamlines.
     """
     nb_streamlines = len(lines)
 
@@ -114,7 +127,7 @@ def propagate_multiple_lines(
         else:
             all_lines_completed = True
 
-    assert not np.any([line is None for line in final_lines])
+    log_gpu_max_allocated(logger)
 
     return final_lines
 

--- a/src/dwi_ml/general/tracking/tracker.py
+++ b/src/dwi_ml/general/tracking/tracker.py
@@ -532,6 +532,7 @@ class DWIMLAbstractTracker:
         idx: List
             List of rejected indices
         """
+        
         # 1) Rejecting streamlines of length 1 (= the seed only). The backward
         # would produce the same result. Overwrite if your model can change
         # results when called twice at the same point.

--- a/src/dwi_ml/general/tracking/tracker.py
+++ b/src/dwi_ml/general/tracking/tracker.py
@@ -395,7 +395,9 @@ class DWIMLAbstractTracker:
         seed_count = 0
         lines = []
         seeds = []
-        with tqdm_logging_redirect(total=self.nbr_seeds, ncols=100) as pbar:
+        with tqdm_logging_redirect(total=self.nbr_seeds,
+                                   loggers=[logging.root],
+                                   ncols=100) as pbar:
             while seed_count < self.nbr_seeds:
                 nb_next_seeds = self.simultaneous_tracking
                 if seed_count + nb_next_seeds > self.nbr_seeds:

--- a/src/dwi_ml/general/tracking/tracker.py
+++ b/src/dwi_ml/general/tracking/tracker.py
@@ -178,7 +178,6 @@ class DWIMLAbstractTracker:
         # -------- Context
         # Uses torch's module eval(), which "turns off" the training mode.
         self.model.eval()
-        self.grad_context = torch.no_grad()
         self.model.set_context('tracking')
 
         # Nb points
@@ -452,7 +451,7 @@ class DWIMLAbstractTracker:
         return clean_lines, clean_seeds
 
     def _propagate_multiple_lines(self, lines: List[Tensor]):
-        with torch.no_grad():
+        with torch.inference_mode():
             return propagate_multiple_lines(
                 lines, self.update_memory_after_removing_lines,
                 self.get_next_dirs, self.theta, self.step_size,
@@ -496,8 +495,7 @@ class DWIMLAbstractTracker:
         raise NotImplementedError
 
     def _call_model_forward(self, inputs, lines):
-        with self.grad_context:
-            model_outputs = self.model(inputs, lines)
+        model_outputs = self.model(inputs, lines)
         return model_outputs
 
     def update_memory_after_removing_lines(self, can_continue: np.ndarray,

--- a/src/dwi_ml/projects/Learn2track/learn2track_tracker.py
+++ b/src/dwi_ml/projects/Learn2track/learn2track_tracker.py
@@ -2,6 +2,7 @@
 import logging
 
 import numpy as np
+import torch
 
 from dwi_ml.projects.Learn2track.learn2track_model import Learn2TrackModel
 from dwi_ml.general.tracking.tracker import DWIMLTrackerOneInput
@@ -61,7 +62,7 @@ class RecurrentTracker(DWIMLTrackerOneInput):
         # nb_streamlines x tensor[nb_points, nb_features]
 
         # No hidden state given = running model on all points.
-        with self.grad_context:
+        with torch.inference_mode():
             _, self.hidden_recurrent_states = self.model(
                 all_inputs, tmp_lines, return_hidden=True, point_idx=None)
 
@@ -72,10 +73,9 @@ class RecurrentTracker(DWIMLTrackerOneInput):
 
     def _call_model_forward(self, inputs, lines):
         # For RNN, we need to send the hidden state too.
-        with self.grad_context:
-            model_outputs, self.hidden_recurrent_states = self.model(
-                inputs, lines, self.hidden_recurrent_states,
-                return_hidden=True, point_idx=-1)
+        model_outputs, self.hidden_recurrent_states = self.model(
+            inputs, lines, self.hidden_recurrent_states,
+            return_hidden=True, point_idx=-1)
 
         return model_outputs
 

--- a/src/dwi_ml/projects/Transformers/transformer_models.py
+++ b/src/dwi_ml/projects/Transformers/transformer_models.py
@@ -23,16 +23,12 @@ from dwi_ml.general.models.main_layers.transformers_from_torch import (
     ModifiedTransformerEncoder, ModifiedTransformerEncoderLayer,
     ModifiedTransformerDecoder, ModifiedTransformerDecoderLayer)
 
-# Our model needs to be autoregressive, to allow inference / generation at
-# tracking time.
-# => During training, we hide the future; both in the input and in the target
-# sequences.
-
-# About the tracking process
-# At each new step, the whole sequence is processed again (ran in the model).
-# We only keep the last output. This is not very efficient... Is there a way
-# to keep the hidden state in-between?
 logger = logging.getLogger('model_logger')  # Same logger as Super.
+
+# For developers. If this is set to true, a few assert(...) calls
+# are made along the way to make sure the code is not broken.
+# (ex, that input lengths fit streamline lengths, and so on).
+DEBUG=False
 
 
 def forward_padding(data: torch.Tensor, expected_length):
@@ -244,9 +240,10 @@ class AbstractTransformerModel(ModelWithNeighborhood, ModelWithDirectionGetter,
         self.dropout = Dropout(self.dropout_rate)
 
         # 1. x embedding layer
-        assert self.computed_input_embedded_size > 3, \
-            "Current computation of the positional encoding required data " \
-            "of size > 3, but got {}".format(self.computed_input_embedded_size)
+        if DEBUG:
+            assert self.computed_input_embedded_size > 3, \
+                "Current computation of the positional encoding required data " \
+                "of size > 3, but got {}".format(self.computed_input_embedded_size)
 
         # 2. positional encoding layer
         cls_p = keys_to_positional_encodings[self.positional_encoding_key]
@@ -406,18 +403,18 @@ class AbstractTransformerModel(ModelWithNeighborhood, ModelWithDirectionGetter,
                 assert average_heads, "Can't average layers without averaging heads."
 
         # ----------- Checks
-        if input_streamlines is not None:
-            # If streamlines are necessary (depending on child class):
-            # In all cases, len(each input) == len(each streamline).
-            # Correct interpolation and management of points should be done
-            # before.
-            assert np.all([len(i) == len(s) for i, s in
-                           zip(inputs, input_streamlines)])
-
         # Remember lengths to unpad outputs later.
         # (except during tracking, we only keep the last output, but still
         # verifying if any length exceeds the max allowed).
         input_lengths = np.asarray([len(i) for i in inputs])
+
+        if input_streamlines is not None and DEBUG:
+            # If streamlines are necessary (depending on child class):
+            # In all cases, len(each input) == len(each streamline).
+            # Correct interpolation and management of points should be done
+            # before.
+            streamline_lengths = np.asarray([len(i) for i in input_streamlines])
+            assert np.array_equal(input_lengths, streamline_lengths)
 
         if np.any(input_lengths > self.max_len):
             raise ValueError("Some streamlines were longer than accepted max "
@@ -439,10 +436,13 @@ class AbstractTransformerModel(ModelWithNeighborhood, ModelWithDirectionGetter,
         # See many discussions in forums, such as
         # https://discuss.pytorch.org/t/about-torch-cuda-empty-cache/34232/26
 
+        # Data is either only the input or (inputs, targets) with targets
+        # being input_streamlines + SOS + EOS
+        data = self._prepare_data(inputs, input_streamlines)
+
         # 1. Embedding + position encoding.
         # Run embedding on padded data. Necessary to make the model
         # adapt for the positional encoding.
-        data = self._prepare_data(inputs, input_streamlines)
         data = self._run_embeddings(data, use_padding, batch_max_len)
         data = self._run_position_encoding(data)
 

--- a/src/dwi_ml/projects/Transformers/transformer_models.py
+++ b/src/dwi_ml/projects/Transformers/transformer_models.py
@@ -554,15 +554,19 @@ class AbstractTransformerModel(ModelWithNeighborhood, ModelWithDirectionGetter,
         raise NotImplementedError
 
     def _run_input_embedding(self, inputs, use_padding, batch_max_len):
-        # toDo: Test faster:
-        #   1) stack (2D), embed, unstack, pad_and_stack (3D)
-        #   2) loop on streamline to embed, pad_and_stack
-        #   3) pad_and_stack, then embed (but we might embed many zeros that
-        #      will be masked in attention anyway)
-
         # Inputs
         inputs = pad_and_stack_batch(inputs, use_padding, batch_max_len)
         inputs = self.input_embedding_layer(inputs)
+
+        # Note. This code runs the embedding on some zeros. They will be
+        # masked in the attention anyway and won't contribute to the training.
+        # But can be heavy for no reason if we have a lot of padding (streamlines
+        # with very variable lengths). Tested this instead, but in my case, it was
+        # not faster:
+        # inputs = torch.vstack(inputs)
+        # inputs = self.input_embedding_layer(inputs)
+        # inputs = torch.split(inputs, list(lengths), dim=0)
+        # inputs = pad_and_stack_batch(inputs, use_padding, batch_max_len)
         return inputs
 
     def merge_batches_outputs(self, all_outputs, new_batch, device=None):

--- a/src/dwi_ml/projects/Transformers/transformer_models.py
+++ b/src/dwi_ml/projects/Transformers/transformer_models.py
@@ -34,16 +34,6 @@ from dwi_ml.general.models.main_layers.transformers_from_torch import (
 # to keep the hidden state in-between?
 logger = logging.getLogger('model_logger')  # Same logger as Super.
 
-# Trying to help with memory.
-# When running out of memory, the error message is:
-# torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate XX (GPU 0;
-# X total capacity; X already allocated; X free; X reserved in total by Torch)
-# If reserved memory is >> allocated memory try setting max_split_size_mb to
-# avoid fragmentation. Value to which to limit is unclear.
-# Tested, does not seem to improve much.
-# os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:512"
-CLEAR_CACHE = False
-
 
 def forward_padding(data: torch.Tensor, expected_length):
     return pad(data, (0, 0, 0, expected_length - len(data)))
@@ -436,8 +426,6 @@ class AbstractTransformerModel(ModelWithNeighborhood, ModelWithDirectionGetter,
         # ----------- Padding params
         use_padding = not np.all(input_lengths == input_lengths[0])
         batch_max_len = np.max(input_lengths)
-        if CLEAR_CACHE:
-            torch.torch.cuda.empty_cache()
 
         # ----------- Prepare masks
         masks = self._prepare_masks(input_lengths, use_padding, batch_max_len)


### PR DESCRIPTION
Tested many things. In the end, barely no change at all, except displaying the GPU usage during tracking, and a very mini save in the transformer forward pass.  Also removed a ToDo (it has been tested).
Plus using torch.inference_mode() rather than torch.no_grad()